### PR TITLE
Added CreateAssetMenu to BacktraceConfiguration ScriptableObject

### DIFF
--- a/Runtime/Model/BacktraceConfiguration.cs
+++ b/Runtime/Model/BacktraceConfiguration.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 namespace Backtrace.Unity.Model
 {
     [Serializable]
+    [CreateAssetMenu(fileName = "New Backtrace Configuration", menuName = "Backtrace/Configuration", order = 0)]
     public class BacktraceConfiguration : ScriptableObject
     {
         /// <summary>


### PR DESCRIPTION
Hello,

Back with a reduced Pull Request with only the addition of `[CreateAssetMenu(fileName = "New Backtrace Configuration", menuName = "Backtrace/Configuration", order = 0)]` to BacktraceConfiguration for inclusion in the default UX for creating ScriptableObjects.

**Note: this removes the need to use the BacktraceMenu class to add a custom menu.**

Cheers,

J.