### PR TITLE
Log manager execution order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Backtrace Unity Release Notes
 
+## Version 3.0.1
+- `BacktraceLogManager` (class responsible for storing log data) will be initialized in `CaptureUnityMessages` method to prevent situation, when custom log from `BacktraceClient` can throw an unhandled exception.
+
 ## Version 3.0.0
 
 *New Features*

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -208,7 +208,7 @@ namespace Backtrace.Unity
                 ? 16 // default maximum game object size
                 : Configuration.GameObjectDepth;
 
-            _backtraceLogManager = new BacktraceLogManager(Configuration.NumberOfLogs);
+            
             CaptureUnityMessages();
             _reportLimitWatcher = new ReportLimitWatcher(Convert.ToUInt32(Configuration.ReportPerMin));
 
@@ -438,6 +438,7 @@ namespace Backtrace.Unity
         /// </summary>
         private void CaptureUnityMessages()
         {
+            _backtraceLogManager = new BacktraceLogManager(Configuration.NumberOfLogs);
             if (Configuration.HandleUnhandledExceptions || Configuration.NumberOfLogs != 0)
             {
                 Application.logMessageReceived += HandleUnityMessage;

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -207,6 +207,8 @@ namespace Backtrace.Unity
             _gameObjectDepth = Configuration.GameObjectDepth == 0
                 ? 16 // default maximum game object size
                 : Configuration.GameObjectDepth;
+
+            _backtraceLogManager = new BacktraceLogManager(Configuration.NumberOfLogs);
             CaptureUnityMessages();
             _reportLimitWatcher = new ReportLimitWatcher(Convert.ToUInt32(Configuration.ReportPerMin));
 
@@ -219,7 +221,6 @@ namespace Backtrace.Unity
 #else
             BacktraceApi = new BacktraceApi(new BacktraceCredentials(Configuration.GetValidServerUrl()));
 #endif
-            _backtraceLogManager = new BacktraceLogManager(Configuration.NumberOfLogs);
             if (!Configuration.DestroyOnLoad)
             {
                 DontDestroyOnLoad(gameObject);


### PR DESCRIPTION
Previously, when the developer edited `BacktraceClient` source code and added `Debug.Log` (or any other log method) between `BacktraceLogManager` initialization and `CaptureUnityMessages` method, in the worst case this will cause an exception in `BacktraceClient` source code.

This diff move `BacktraceLogManager` initialization to `CaptureUnityMessages` method. We decided to initialize manager there because `BacktraceLogManager` is a required dependency of `CaptureUnityMessages` method.

https://github.com/backtrace-labs/backtrace-unity/issues/28