### PR TITLE
Store crash image in JPG format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Backtrace Unity Release Notes
 
+## Version 3.0.1
+- The backtrace-unity library (Backtrace) will generate new image files in .jpg format. 
+
 ## Version 3.0.0
 
 *New Features*

--- a/Runtime/Model/Database/BacktraceDatabaseAttachmentManager.cs
+++ b/Runtime/Model/Database/BacktraceDatabaseAttachmentManager.cs
@@ -69,7 +69,7 @@ namespace Backtrace.Unity.Model.Database
             {
                 return string.Empty;
             }
-            var screenshotPath = Path.Combine(_settings.DatabasePath, string.Format("{0}.png", backtraceData.Uuid));
+            var screenshotPath = Path.Combine(_settings.DatabasePath, string.Format("{0}.jpg", backtraceData.Uuid));
 
             lock (_lock)
             {
@@ -93,8 +93,8 @@ namespace Backtrace.Unity.Model.Database
                     tex.ReadPixels(new Rect(0, 0, width, height), 0, 0);
                     tex.Apply();
 
-                    // Encode texture into PNG
-                    byte[] bytes = tex.EncodeToPNG();
+                    // Encode texture into JPG
+                    byte[] bytes = tex.EncodeToJPG();
 
                     // For testing purposes, also write to a file in the project folder
                     File.WriteAllBytes(screenshotPath, bytes);


### PR DESCRIPTION
Previously, the Backtrace-Unity library tried to generate a crash image in PNG format. Because of that, the image size was unacceptable. Comparison between JPG and PNG showed that JPG size is much smaller (the same image - PNG: 376KB vs JPG: 31,6KB).

This diff changes the default image type to JPG.


https://github.com/backtrace-labs/backtrace-unity/issues/26