### PR TITLE
ANR watchdog initialization

### DIFF
--- a/Android/BacktraceANRWatchdog.java
+++ b/Android/BacktraceANRWatchdog.java
@@ -63,14 +63,11 @@ public class BacktraceANRWatchdog extends Thread {
      * Initialize new instance of BacktraceANRWatchdog with default timeout
      */
     public BacktraceANRWatchdog(String gameObjectName, String methodName) {
-        Log.d(LOG_TAG, "Backtrace::inside constructor");
         Log.d(LOG_TAG, "Initializing ANR watchdog");
         this.methodName = methodName;
         this.gameObjectName = gameObjectName;
-
         this.timeout = DEFAULT_ANR_TIMEOUT;
         this.debug = false;
-        Log.d(LOG_TAG, "Backtrace::Starting watcher");
         BacktraceANRWatchdog._instance = this;
         this.start();
     }

--- a/Android/BacktraceANRWatchdog.java
+++ b/Android/BacktraceANRWatchdog.java
@@ -18,10 +18,6 @@ import java.util.Calendar;
 public class BacktraceANRWatchdog extends Thread {
 
     private static BacktraceANRWatchdog _instance;
-    //todo: set anr timeout based on backtrace-unity configuration 
-    static public void watch (String gameObjectName, String methodName){
-        BacktraceANRWatchdog._instance = new BacktraceANRWatchdog(gameObjectName,methodName);
-    }
 
     private final static transient String LOG_TAG = BacktraceANRWatchdog.class.getSimpleName();
 
@@ -67,12 +63,15 @@ public class BacktraceANRWatchdog extends Thread {
      * Initialize new instance of BacktraceANRWatchdog with default timeout
      */
     public BacktraceANRWatchdog(String gameObjectName, String methodName) {
+        Log.d(LOG_TAG, "Backtrace::inside constructor");
         Log.d(LOG_TAG, "Initializing ANR watchdog");
         this.methodName = methodName;
         this.gameObjectName = gameObjectName;
 
         this.timeout = DEFAULT_ANR_TIMEOUT;
         this.debug = false;
+        Log.d(LOG_TAG, "Backtrace::Starting watcher");
+        BacktraceANRWatchdog._instance = this;
         this.start();
     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Backtrace Unity Release Notes
 
+## Version 3.0.1
+- Fixed ANR watchdog initialization - right now Backtrace native client will create class instance of `BacktraceAnrWatchdog` class, instead of creating instance via static class method.
+
 ## Version 3.0.0
 
 *New Features*

--- a/Runtime/Native/Android/NativeClient.cs
+++ b/Runtime/Native/Android/NativeClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 namespace Backtrace.Unity.Runtime.Native.Android
@@ -16,7 +17,7 @@ namespace Backtrace.Unity.Runtime.Native.Android
         /// <summary>
         /// Determine if android integration should be enabled
         /// </summary>
-        private readonly bool _enabled = Application.platform == RuntimePlatform.Android;
+        private bool _enabled = Application.platform == RuntimePlatform.Android;
 
         /// <summary>
         /// Anr watcher object
@@ -71,8 +72,15 @@ namespace Backtrace.Unity.Runtime.Native.Android
         /// <param name="callbackName">Callback function name</param>
         public void HandleAnr(string gameObjectName, string callbackName)
         {
-            _anrWatcher = new AndroidJavaObject(_anrPath);
-            _anrWatcher.CallStatic("watch", gameObjectName, callbackName);
+            try
+            {
+                _anrWatcher = new AndroidJavaObject(_anrPath, gameObjectName, callbackName);
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning(string.Format("Cannot initialize ANR watchdog - reason: {0}", e.Message));
+                _enabled = false;
+            }
         }
     }
 }


### PR DESCRIPTION
Previously Backtrace native client initialized ANR watchdog via a static java method. This caused a problems in Android 7 `AndroidJavaException: java.lang.NoSuchMethodError: no non-static method "Lbacktrace/io/backtrace_unity_android_plugin/BacktraceANRWatchdog;.<init>()V"`

This diff changes a way how we initialize ANR watchdog - right now we will use BacktraceANRWatchdog constructor instead.