### PR TITLE
Feature/database improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `BacktraceClient` will try to reuse database JSON - if Backtrace client has acccess to Backtrace database,
 - `BacktraceDatabase` `AutoSend` property improvements - now we will discard any calculations in `Update` method,
 - `BacktraceClient` by default will generate configuraiton file with client rate limit equal to 50.
+- Fixed invalid meta file.
 
 ## Version 3.0.1
 - The `BacktraceDatabase` class will now create database directory before final database validation. Previously, when directory didn't exist, BacktraceDatabase was disabled.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Backtrace Unity Release Notes
 
+## Version 3.0.2
+- `BacktraceDatabase` now allows to send object via `Send` method. This method will try to send all objects from database - with all respects to the Database settings.
+- `BacktraceClient` will try to reuse database JSON - if Backtrace client has acccess to Backtrace database,
+- `BacktraceDatabase` `AutoSend` property improvements - now we will discard any calculations in `Update` method,
+- `BacktraceClient` by default will generate configuraiton file with client rate limit equal to 50.
+
 ## Version 3.0.1
 - The `BacktraceDatabase` class will now create database directory before final database validation. Previously, when directory didn't exist, BacktraceDatabase was disabled.
 - The `BacktraceDatabase` field now allows users to pass interpolated string in Database options. Developer can use `${Application.dataPath}` or `${Application.persistentDataPath}` to set path to database. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Backtrace Unity Release Notes
 
 ## Version 3.0.2
-- `BacktraceDatabase` now allows to send object via `Send` method. This method will try to send all objects from database - with all respects to the Database settings.
-- `BacktraceClient` will try to reuse database JSON - if Backtrace client has acccess to Backtrace database,
-- `BacktraceDatabase` `AutoSend` property improvements - now we will discard any calculations in `Update` method,
-- `BacktraceClient` by default will generate configuraiton file with client rate limit equal to 50.
+- `BacktraceDatabase` now provides a new `Send` method. This method will try to send all objects from the database respecting the client side deduplication and retry setting. This can be used as an alternative to the `Flush` method which will try to send all objects from the database ignoring any client side deduplication and retry settings.
+- `BacktraceClient` has been optimized to only serialize data as needed.
+- `BacktraceDatabase` `AutoSend` function has been optimized for performance improvements.
+- `BacktraceClient` by default will generate configuration file with client rate limit equal to 50.
 - Fixed invalid meta file.
 
 ## Version 3.0.1

--- a/Editor/BacktraceConfigurationLabels.cs.meta
+++ b/Editor/BacktraceConfigurationLabels.cs.meta
@@ -1,9 +1,5 @@
 fileFormatVersion: 2
-<<<<<<< HEAD:Runtime/Common/StackFrameHelper.cs.meta
 guid: 6418a5b01b0792e4da8a23b9c207c09c
-=======
-guid: 81af1b5bf4a7292469f7fd6c0bacfed1
->>>>>>> feature/fingerprintBehavior:Editor/BacktraceConfigurationLabels.cs.meta
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Runtime/Interfaces/IBacktraceAPI.cs
+++ b/Runtime/Interfaces/IBacktraceAPI.cs
@@ -11,6 +11,10 @@ namespace Backtrace.Unity.Interfaces
     public interface IBacktraceApi
     {
         /// <summary>
+        /// Server url
+        /// </summary>
+        string ServerUrl { get; }
+        /// <summary>
         /// Send a Backtrace report to Backtrace API
         /// </summary>
         /// <param name="data">Library diagnostic data</param>

--- a/Runtime/Interfaces/IBacktraceDatabase.cs
+++ b/Runtime/Interfaces/IBacktraceDatabase.cs
@@ -80,7 +80,8 @@ namespace Backtrace.Unity.Interfaces
         /// Add Backtrace data to database
         /// </summary>
         /// <param name="data">Backtrace data</param>
+        /// <param name="lock">Lock report - default true</param>
         /// <returns>Backtrace record</returns>
-        BacktraceDatabaseRecord Add(BacktraceData data);
+        BacktraceDatabaseRecord Add(BacktraceData data, bool @lock = true);
     }
 }

--- a/Runtime/Model/BacktraceConfiguration.cs
+++ b/Runtime/Model/BacktraceConfiguration.cs
@@ -23,8 +23,8 @@ namespace Backtrace.Unity.Model
         /// <summary>
         /// Maximum number reports per minute
         /// </summary>
-        [Tooltip("Reports per minute: Limits the number of reports the client will send per minutes. If set to 0, there is no limit. If set to a higher value and the value is reached, the client will not send any reports until the next minute.")]
-        public int ReportPerMin;
+        [Tooltip("Reports per minute: Limits the number of reports the client will send per minutes. If set to 0, there is no limit. If set to a higher value and the value is reached, the client will not send any reports until the next minute. Default: 50")]
+        public int ReportPerMin = 50;
 
         /// <summary>
         /// Determine if client should catch unhandled exceptions

--- a/Runtime/Model/BacktraceData.cs
+++ b/Runtime/Model/BacktraceData.cs
@@ -45,7 +45,7 @@ namespace Backtrace.Unity.Model
         /// <summary>
         /// Version of the C# library
         /// </summary>
-        public const string AgentVersion = "3.0.1";
+        public const string AgentVersion = "3.0.2";
 
         /// <summary>
         /// Application thread details

--- a/Runtime/Model/BacktraceDatabaseConfiguration.cs
+++ b/Runtime/Model/BacktraceDatabaseConfiguration.cs
@@ -15,7 +15,7 @@ namespace Backtrace.Unity.Model
         public string DatabasePath;
 
         /// <summary>
-        /// Resend report when http client throw exception
+        /// When toggled on, the database will send automatically reports to Backtrace server based on the Retry Settings below. When toggled off, the developer will need to use the Flush method to attempt to send and clear. Recommend that this is toggled on.
         /// </summary>
         public bool AutoSendMode = true;
 

--- a/Runtime/Model/Database/BacktraceDatabaseRecord.cs
+++ b/Runtime/Model/Database/BacktraceDatabaseRecord.cs
@@ -58,6 +58,8 @@ namespace Backtrace.Unity.Model.Database
         /// </summary>
         public List<string> Attachments { get; private set; }
 
+        private string _diagnosticDataJson;
+
         public bool Duplicated
         {
             get
@@ -84,6 +86,11 @@ namespace Backtrace.Unity.Model.Database
 
         public string BacktraceDataJson()
         {
+            if (!string.IsNullOrEmpty(_diagnosticDataJson))
+            {
+                return _diagnosticDataJson;
+            }
+
             if (Record != null)
             {
                 return Record.ToJson();
@@ -166,8 +173,8 @@ namespace Backtrace.Unity.Model.Database
         {
             try
             {
-                var diagnosticDataJson = Record.ToJson();
-                DiagnosticDataPath = Save(diagnosticDataJson, string.Format("{0}-attachment", Id));
+                _diagnosticDataJson = Record.ToJson();
+                DiagnosticDataPath = Save(_diagnosticDataJson, string.Format("{0}-attachment", Id));
 
                 if (Attachments != null && Attachments.Any())
                 {
@@ -342,6 +349,7 @@ namespace Backtrace.Unity.Model.Database
             {
                 Locked = false;
                 Record = null;
+                _diagnosticDataJson = string.Empty;
             }
         }
 

--- a/Runtime/Model/Database/BacktraceDatabaseSettings.cs
+++ b/Runtime/Model/Database/BacktraceDatabaseSettings.cs
@@ -51,7 +51,7 @@ namespace Backtrace.Unity.Model.Database
         }
 
         /// <summary>
-        /// Resend report when http client throw exception
+        /// Automatically send data from Backtrace database
         /// </summary>
         public bool AutoSendMode
         {

--- a/Runtime/Services/BacktraceApi.cs
+++ b/Runtime/Services/BacktraceApi.cs
@@ -37,6 +37,17 @@ namespace Backtrace.Unity.Services
         /// </summary>
         private readonly Uri _serverurl;
 
+        /// <summary>
+        /// Url to server
+        /// </summary>
+        public string ServerUrl
+        {
+            get
+            {
+                return _serverurl.ToString();
+            }
+        }
+
 
         private readonly BacktraceCredentials _credentials;
 
@@ -77,7 +88,7 @@ namespace Backtrace.Unity.Services
         
 #endif
 
- /// <summary>
+        /// <summary>
         /// Send minidump to Backtrace
         /// </summary>
         /// <param name="minidumpPath">Path to minidump</param>
@@ -91,7 +102,7 @@ namespace Backtrace.Unity.Services
                 attachments = new List<string>();
             }
 
-            var jsonServerUrl = _serverurl.ToString();
+            var jsonServerUrl = ServerUrl;
             var minidumpServerUrl = jsonServerUrl.IndexOf("submit.backtrace.io") != -1
                 ? jsonServerUrl.Replace("/json", "/minidump")
                 : jsonServerUrl.Replace("format=json", "format=minidump");
@@ -103,7 +114,7 @@ namespace Backtrace.Unity.Services
 
             foreach (var file in attachments)
             {
-                 if (File.Exists(file) && new FileInfo(file).Length > 10000000)
+                if (File.Exists(file) && new FileInfo(file).Length > 10000000)
                 {
                     formData.Add(new MultipartFormFileSection(
                         string.Format("attachment__{0}", Path.GetFileName(file)),
@@ -148,7 +159,7 @@ namespace Backtrace.Unity.Services
 #pragma warning disable CS0618 // Type or member is obsolete
             if (RequestHandler != null)
             {
-                yield return RequestHandler.Invoke(_serverurl.ToString(), data);
+                yield return RequestHandler.Invoke(ServerUrl, data);
             }
             else if (data != null)
             {
@@ -169,7 +180,7 @@ namespace Backtrace.Unity.Services
         /// <returns>Server response</returns>
         public IEnumerator Send(string json, List<string> attachments, int deduplication, Action<BacktraceResult> callback)
         {
-            var requestUrl = _serverurl.ToString();
+            var requestUrl = ServerUrl;
             if (deduplication > 0)
             {
                 var startingChar = string.IsNullOrEmpty(_serverurl.Query) ? "?" : "&";

--- a/Tests/Runtime/BacktraceClientTests.cs
+++ b/Tests/Runtime/BacktraceClientTests.cs
@@ -4,6 +4,7 @@ using Backtrace.Unity.Types;
 using NUnit.Framework;
 using System;
 using System.Collections;
+using UnityEngine;
 using UnityEngine.TestTools;
 
 namespace Backtrace.Unity.Tests.Runtime
@@ -108,6 +109,7 @@ namespace Backtrace.Unity.Tests.Runtime
                 return backtraceData;
             };
             BacktraceClient.Send(new Exception("test exception"));
+            yield return new WaitForEndOfFrame();
             Assert.IsTrue(trigger);
             yield return null;
         }
@@ -127,12 +129,13 @@ namespace Backtrace.Unity.Tests.Runtime
                 return new BacktraceResult();
             };
             BacktraceClient.Send(new Exception("test exception"));
+            yield return new WaitForEndOfFrame();
             Assert.IsTrue(trigger);
             yield return null;
         }
 
-       [Test]
-        public void TestFingerprintBehaviorForNormalizedExceptionMessage_ShouldGenerateFingerprintForExceptionReportWithoutStackTrace_ShouldIncludeFingerprintInBacktraceReport()
+       [UnityTest]
+        public IEnumerator TestFingerprintBehaviorForNormalizedExceptionMessage_ShouldGenerateFingerprintForExceptionReportWithoutStackTrace_ShouldIncludeFingerprintInBacktraceReport()
         {
             BacktraceClient.Configuration = GetValidClientConfiguration();
             BacktraceClient.Configuration.UseNormalizedExceptionMessage = true;
@@ -154,11 +157,12 @@ namespace Backtrace.Unity.Tests.Runtime
                 return null;
             };
             BacktraceClient.Send(report);
+            yield return new WaitForEndOfFrame();
             Assert.IsTrue(eventFired);
         }
 
-        [Test]
-        public void TestFingerprintBehaviorForNormalizedExceptionMessage_ShouldntGenerateFingerprintForDisabledOption_FingerprintDoesntExist()
+        [UnityTest]
+        public IEnumerator TestFingerprintBehaviorForNormalizedExceptionMessage_ShouldntGenerateFingerprintForDisabledOption_FingerprintDoesntExist()
         {
             BacktraceClient.Configuration = GetValidClientConfiguration();
             BacktraceClient.Configuration.UseNormalizedExceptionMessage = false;
@@ -179,11 +183,12 @@ namespace Backtrace.Unity.Tests.Runtime
                 return null;
             };
             BacktraceClient.Send(report);
+            yield return new WaitForEndOfFrame();
             Assert.IsTrue(eventFired);
         }
 
-        [Test]
-        public void TestFingerprintBehaviorForNormalizedExceptionMessage_ShouldUseReportFingerprint_ReportFingerprintInAttributes()
+        [UnityTest]
+        public IEnumerator TestFingerprintBehaviorForNormalizedExceptionMessage_ShouldUseReportFingerprint_ReportFingerprintInAttributes()
         {
             BacktraceClient.Configuration = GetValidClientConfiguration();
             BacktraceClient.Configuration.UseNormalizedExceptionMessage = true;
@@ -206,6 +211,8 @@ namespace Backtrace.Unity.Tests.Runtime
                 return null;
             };
             BacktraceClient.Send(report);
+            yield return new WaitForEndOfFrame();
+
             Assert.IsTrue(eventFired);
         }
 
@@ -223,8 +230,8 @@ namespace Backtrace.Unity.Tests.Runtime
         }
 
 
-        [Test]
-        public void TestFingerprintBehaviorForNormalizedExceptionMessage_ShouldGenerateFingerprintAndShouldntRemoveAnyLetter_ShouldIncludeFingerprintInBacktraceReport()
+        [UnityTest]
+        public IEnumerator TestFingerprintBehaviorForNormalizedExceptionMessage_ShouldGenerateFingerprintAndShouldntRemoveAnyLetter_ShouldIncludeFingerprintInBacktraceReport()
         {
             BacktraceClient.Configuration = GetValidClientConfiguration();
             BacktraceClient.Configuration.UseNormalizedExceptionMessage = true;
@@ -243,11 +250,12 @@ namespace Backtrace.Unity.Tests.Runtime
                 return null;
             };
             BacktraceClient.Send(report);
+            yield return new WaitForEndOfFrame();
             Assert.IsTrue(eventFired);
         }
 
-        [Test]
-        public void TestFingerprintBehaviorForNormalizedExceptionMessage_ShouldntGenerateFingerprintForExistingStackTrace_ShouldIgnoreAttributeFingerprint()
+        [UnityTest]
+        public IEnumerator TestFingerprintBehaviorForNormalizedExceptionMessage_ShouldntGenerateFingerprintForExistingStackTrace_ShouldIgnoreAttributeFingerprint()
         {
 
             BacktraceClient.Configuration = GetValidClientConfiguration();
@@ -266,6 +274,7 @@ namespace Backtrace.Unity.Tests.Runtime
                 return null;
             };
             BacktraceClient.Send(report);
+            yield return new WaitForEndOfFrame();
             Assert.IsTrue(eventFired);
         }
     }

--- a/Tests/Runtime/ClientSendTests.cs
+++ b/Tests/Runtime/ClientSendTests.cs
@@ -38,6 +38,8 @@ namespace Backtrace.Unity.Tests.Runtime
                 return new BacktraceResult();
             };
             client.Send(exception);
+
+            yield return new WaitForEndOfFrame();
             Assert.IsTrue(trigger);
             yield return null;
         }
@@ -59,6 +61,7 @@ namespace Backtrace.Unity.Tests.Runtime
             {
                 trigger = true;
             });
+            yield return new WaitForEndOfFrame();
             Assert.IsTrue(trigger);
             yield return null;
         }

--- a/Tests/Runtime/Mocks/BacktraceApiMock.cs
+++ b/Tests/Runtime/Mocks/BacktraceApiMock.cs
@@ -13,6 +13,14 @@ namespace Backtrace.Unity.Tests.Runtime
         public Action<BacktraceResult> OnServerResponse { get; set; }
         public Func<string, BacktraceData, BacktraceResult> RequestHandler { get; set; }
 
+        public string ServerUrl
+        {
+            get
+            {
+                return string.Empty;
+            }
+        }
+
         public IEnumerator Send(BacktraceData data, Action<BacktraceResult> callback = null)
         {
             LastData = data;
@@ -25,6 +33,10 @@ namespace Backtrace.Unity.Tests.Runtime
 
         public IEnumerator Send(string json, List<string> attachments, int deduplication, Action<BacktraceResult> callback)
         {
+            if (callback != null)
+            {
+                callback.Invoke(new BacktraceResult() { Status = Types.BacktraceResultStatus.Ok });
+            }
             yield return null;
         }
 

--- a/Tests/Runtime/SourceCode/SourceCodeFlowWithLogManagerTests.cs
+++ b/Tests/Runtime/SourceCode/SourceCodeFlowWithLogManagerTests.cs
@@ -1,7 +1,10 @@
 ﻿using Backtrace.Unity.Model;
 using NUnit.Framework;
 using System;
+using System.Collections;
 using System.Linq;
+using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace Backtrace.Unity.Tests.Runtime
 {
@@ -10,7 +13,7 @@ namespace Backtrace.Unity.Tests.Runtime
         private readonly BacktraceApiMock api = new BacktraceApiMock();
         private readonly int _numberOfLogs = 10;
 
-        [OneTimeSetUp]
+        [SetUp]
         public void Setup()
         {
             BeforeSetup();
@@ -22,12 +25,20 @@ namespace Backtrace.Unity.Tests.Runtime
             BacktraceClient.BacktraceApi = api;
         }
 
-        [Test]
-        public void TestSourceCodeAssignment_EnabledLogManagerAndSendExceptionReport_SourceCodeAvailable()
+        [UnityTest]
+        public IEnumerator TestSourceCodeAssignment_EnabledLogManagerAndSendExceptionReport_SourceCodeAvailable()
         {
+            BacktraceData lastData = null;
+            BacktraceClient.BeforeSend = (BacktraceData data) =>
+            {
+                lastData = data;
+                return data;
+            };
+
             BacktraceClient.Send(new Exception("foo"));
+            yield return new WaitForEndOfFrame();
 
-            var lastData = api.LastData;
+
             Assert.IsNotNull(lastData.SourceCode);
 
             var threadName = lastData.ThreadData.MainThread;
@@ -35,12 +46,19 @@ namespace Backtrace.Unity.Tests.Runtime
         }
 
 
-        [Test]
-        public void TestSourceCodeAssignment_EnabledLogManagerAndSendMessageReport_SourceCodeAvailable()
+        [UnityTest]
+        public IEnumerator TestSourceCodeAssignment_EnabledLogManagerAndSendMessageReport_SourceCodeAvailable()
         {
+            BacktraceData lastData = null;
+            BacktraceClient.BeforeSend = (BacktraceData data) =>
+            {
+                lastData = data;
+                return data;
+            };
+
             BacktraceClient.Send("foo");
+            yield return new WaitForEndOfFrame();
 
-            var lastData = api.LastData;
             Assert.IsNotNull(lastData.SourceCode);
 
             var threadName = lastData.ThreadData.MainThread;
@@ -48,44 +66,62 @@ namespace Backtrace.Unity.Tests.Runtime
         }
 
 
-        [Test]
-        public void TestSourceCodeAssignment_EnabledLogManagerAndSendUnhandledException_SourceCodeAvailable()
+        [UnityTest]
+        public IEnumerator TestSourceCodeAssignment_EnabledLogManagerAndSendUnhandledException_SourceCodeAvailable()
         {
-            BacktraceClient.HandleUnityMessage("foo", string.Empty, UnityEngine.LogType.Exception);
+            BacktraceData lastData = null;
+            BacktraceClient.BeforeSend = (BacktraceData data) =>
+            {
+                lastData = data;
+                return data;
+            };
 
-            var lastData = api.LastData;
+            BacktraceClient.HandleUnityMessage("foo", string.Empty, LogType.Exception);
+            yield return new WaitForEndOfFrame();
+
             Assert.IsNotNull(lastData.SourceCode);
 
             var threadName = lastData.ThreadData.MainThread;
             Assert.AreEqual(lastData.SourceCode.Id, lastData.ThreadData.ThreadInformations[threadName].Stack.First().SourceCode);
         }
 
-        [Test]
-        public void TestSourceCodeAssignment_EnabledLogManagerAndSendUnhandledError_SourceCodeAvailable()
+        [UnityTest]
+        public IEnumerator TestSourceCodeAssignment_EnabledLogManagerAndSendUnhandledError_SourceCodeAvailable()
         {
-            BacktraceClient.HandleUnityMessage("foo", string.Empty, UnityEngine.LogType.Error);
+            BacktraceData lastData = null;
+            BacktraceClient.BeforeSend = (BacktraceData data) =>
+            {
+                lastData = data;
+                return data;
+            };
 
-            var lastData = api.LastData;
+            BacktraceClient.HandleUnityMessage("foo", string.Empty, LogType.Error);
+            yield return new WaitForEndOfFrame();
             Assert.IsNotNull(lastData.SourceCode);
 
             var threadName = lastData.ThreadData.MainThread;
             Assert.AreEqual(lastData.SourceCode.Id, lastData.ThreadData.ThreadInformations[threadName].Stack.First().SourceCode);
         }
 
-        [Test]
-        public void TestSourceCodeAssignment_EnabledLogManagerWithMultipleLogMessage_SourceCodeAvailable()
+        [UnityTest]
+        public IEnumerator TestSourceCodeAssignment_EnabledLogManagerWithMultipleLogMessage_SourceCodeAvailable()
         {
+            BacktraceData lastData = null;
+            BacktraceClient.BeforeSend = (BacktraceData data) =>
+            {
+                lastData = data;
+                return data;
+            };
             //fake messages
             var fakeLogMessage = "log";
-            BacktraceClient.HandleUnityMessage(fakeLogMessage, string.Empty, UnityEngine.LogType.Log);
+            BacktraceClient.HandleUnityMessage(fakeLogMessage, string.Empty, LogType.Log);
             var fakeWarningMessage = "warning message";
-            BacktraceClient.HandleUnityMessage(fakeWarningMessage, string.Empty, UnityEngine.LogType.Warning);
+            BacktraceClient.HandleUnityMessage(fakeWarningMessage, string.Empty, LogType.Warning);
 
             // real exception
             var expectedExceptionMessage = "Exception message";
-            BacktraceClient.HandleUnityMessage(expectedExceptionMessage, string.Empty, UnityEngine.LogType.Exception);
-
-            var lastData = api.LastData;
+            BacktraceClient.HandleUnityMessage(expectedExceptionMessage, string.Empty, LogType.Exception);
+            yield return new WaitForEndOfFrame();
             Assert.IsNotNull(lastData.SourceCode);
 
             var generatedText = lastData.SourceCode.Text;
@@ -94,20 +130,28 @@ namespace Backtrace.Unity.Tests.Runtime
             Assert.IsTrue(generatedText.Contains(fakeWarningMessage));
         }
 
-        [Test]
-        public void TestSourceCodeAssignment_EnabledLogManagerWithMultipleLogMessageAndExceptionReport_SourceCodeAvailable()
+        [UnityTest]
+        public IEnumerator TestSourceCodeAssignment_EnabledLogManagerWithMultipleLogMessageAndExceptionReport_SourceCodeAvailable()
         {
+            BacktraceData lastData = null;
+            BacktraceClient.BeforeSend = (BacktraceData data) =>
+            {
+                lastData = data;
+                return data;
+            };
             //fake messages
             var fakeLogMessage = "log";
-            BacktraceClient.HandleUnityMessage(fakeLogMessage, string.Empty, UnityEngine.LogType.Log);
+            BacktraceClient.HandleUnityMessage(fakeLogMessage, string.Empty, LogType.Log);
+            yield return new WaitForEndOfFrame();
             var fakeWarningMessage = "warning message";
-            BacktraceClient.HandleUnityMessage(fakeWarningMessage, string.Empty, UnityEngine.LogType.Warning);
+            BacktraceClient.HandleUnityMessage(fakeWarningMessage, string.Empty, LogType.Warning);
+            yield return new WaitForEndOfFrame();
 
             // real exception
             var expectedExceptionMessage = "Exception message";
             BacktraceClient.Send(new Exception(expectedExceptionMessage));
+            yield return new WaitForEndOfFrame();
 
-            var lastData = api.LastData;
             Assert.IsNotNull(lastData.SourceCode);
 
             var generatedText = lastData.SourceCode.Text;
@@ -117,20 +161,27 @@ namespace Backtrace.Unity.Tests.Runtime
         }
 
 
-        [Test]
-        public void TestSourceCodeAssignment_EnabledLogManagerWithMultipleLogMessageAndMessageReport_SourceCodeAvailable()
+        [UnityTest]
+        public IEnumerator TestSourceCodeAssignment_EnabledLogManagerWithMultipleLogMessageAndMessageReport_SourceCodeAvailable()
         {
+            BacktraceData lastData = null;
+            BacktraceClient.BeforeSend = (BacktraceData data) =>
+            {
+                lastData = data;
+                return data;
+            };
             //fake messages
             var fakeLogMessage = "log";
-            BacktraceClient.HandleUnityMessage(fakeLogMessage, string.Empty, UnityEngine.LogType.Log);
+            BacktraceClient.HandleUnityMessage(fakeLogMessage, string.Empty, LogType.Log);
+            yield return new WaitForEndOfFrame();
             var fakeWarningMessage = "warning message";
-            BacktraceClient.HandleUnityMessage(fakeWarningMessage, string.Empty, UnityEngine.LogType.Warning);
+            BacktraceClient.HandleUnityMessage(fakeWarningMessage, string.Empty, LogType.Warning);
+            yield return new WaitForEndOfFrame();
 
             // real exception
             var expectedExceptionMessage = "Exception message";
             BacktraceClient.Send(expectedExceptionMessage);
-
-            var lastData = api.LastData;
+            yield return new WaitForEndOfFrame();
             Assert.IsNotNull(lastData.SourceCode);
 
             var generatedText = lastData.SourceCode.Text;
@@ -139,28 +190,37 @@ namespace Backtrace.Unity.Tests.Runtime
             Assert.IsTrue(generatedText.Contains(fakeWarningMessage));
         }
 
-        [Test]
-        public void TestSourceCodeAssignment_DisabledUnhandledException_ShouldStoreUnhandledExceptionInfo()
+        [UnityTest]
+        public IEnumerator TestSourceCodeAssignment_DisabledUnhandledException_ShouldStoreUnhandledExceptionInfo()
         {
             BacktraceClient.Configuration.HandleUnhandledExceptions = false;
 
-            api.LastData = null;
+            BacktraceData lastData = null;
+            BacktraceClient.BeforeSend = (BacktraceData data) =>
+            {
+                lastData = data;
+                return data;
+            };
 
             //fake messages
             var fakeLogMessage = "log";
-            BacktraceClient.HandleUnityMessage(fakeLogMessage, string.Empty, UnityEngine.LogType.Log);
+            BacktraceClient.HandleUnityMessage(fakeLogMessage, string.Empty, LogType.Log);
+            yield return new WaitForEndOfFrame();
+
             var fakeWarningMessage = "warning message";
-            BacktraceClient.HandleUnityMessage(fakeWarningMessage, string.Empty, UnityEngine.LogType.Warning);
+            BacktraceClient.HandleUnityMessage(fakeWarningMessage, string.Empty, LogType.Warning);
+            yield return new WaitForEndOfFrame();
 
             // real exception
             var expectedExceptionMessage = "Exception message";
-            BacktraceClient.HandleUnityMessage(expectedExceptionMessage, string.Empty, UnityEngine.LogType.Exception);
+            BacktraceClient.HandleUnityMessage(expectedExceptionMessage, string.Empty, LogType.Exception);
+            yield return new WaitForEndOfFrame();
             Assert.IsNull(api.LastData);
 
             var expectedReportMessage = "Report message";
             var report = new BacktraceReport(new Exception(expectedReportMessage));
             BacktraceClient.Send(report);
-            var lastData = api.LastData;
+            yield return new WaitForEndOfFrame();
             Assert.IsNotNull(lastData.SourceCode);
 
             var generatedText = lastData.SourceCode.Text;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "io.backtrace.unity",
   "displayName": "Backtrace",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "unity": "2017.1",
   "description": "Backtrace's integration with Unity games allows customers to capture and report handled and unhandled Unity exceptions to their Backtrace instance, instantly offering the ability to prioritize and debug software errors.",
   "keywords": [


### PR DESCRIPTION
## Version 3.0.2
- `BacktraceDatabase` now provides a new `Send` method. This method will try to send all objects from the database respecting the client side deduplication and retry setting. This can be used as an alternative to the `Flush` method which will try to send all objects from the database ignoring any client side deduplication and retry settings.
- `BacktraceClient` has been optimized to only serialize data as needed.
- `BacktraceDatabase` `AutoSend` function has been optimized for performance improvements.
- `BacktraceClient` by default will generate configuration file with client rate limit equal to 50.
- Fixed invalid meta file.
