### PR TITLE
Version 3.3.2 - ANR detection fix 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Backtrace Unity Release Notes
 
+## Version 3.3.2
+- ANR detection algorithm now uses `Time.unscaledTime` instead of `Time.time` to prevent ANR detection when game is paused.
+
 ## Version 3.3.1
 - Improved Out-of-memory detection on iOS - Backtrace will report Out-of-memory exceptions when a memory warning occured and the application unexpectly closed. The Out-of-memory watcher will analyse game version, system version, debugger information and even more to determine if application closed by Out-of-memory exception or not.
 - Backtrace will no longer send low memory warnings reports from Android or iOS. Instead, Backtrace will utilize iOS OOM detection and extend the embedded native report attributes on Android.

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -20,7 +20,7 @@ namespace Backtrace.Unity
     {
         public BacktraceConfiguration Configuration;
 
-        public const string VERSION = "3.3.1";
+        public const string VERSION = "3.3.2";
         public bool Enabled { get; private set; }
 
         /// <summary>
@@ -415,7 +415,7 @@ namespace Backtrace.Unity
         /// </summary>
         private void Update()
         {
-            _nativeClient?.UpdateClientTime(Time.time);
+            _nativeClient?.UpdateClientTime(Time.unscaledTime);
         }
 
         private void OnDestroy()

--- a/Runtime/BacktraceDatabase.cs
+++ b/Runtime/BacktraceDatabase.cs
@@ -139,8 +139,8 @@ namespace Backtrace.Unity
             //setup database object
             DatabaseSettings = new BacktraceDatabaseSettings(DatabasePath, Configuration);
             SetupMultisceneSupport();
-            _lastConnection = Time.time;
-            LastFrameTime = Time.time;
+            _lastConnection = Time.unscaledTime;
+            LastFrameTime = Time.unscaledTime;
             //Setup database context
             BacktraceDatabaseContext = new BacktraceDatabaseContext(DatabaseSettings);
             BacktraceDatabaseFileContext = new BacktraceDatabaseFileContext(DatabaseSettings.DatabasePath, DatabaseSettings.MaxDatabaseSize, DatabaseSettings.MaxRecordCount);
@@ -174,15 +174,15 @@ namespace Backtrace.Unity
             {
                 return;
             }
-            LastFrameTime = Time.time;
+            LastFrameTime = Time.tiunscaledTimeme;
             if (!DatabaseSettings.AutoSendMode)
             {
                 return;
             }
 
-            if (Time.time - _lastConnection > DatabaseSettings.RetryInterval)
+            if (Time.unscaledTime - _lastConnection > DatabaseSettings.RetryInterval)
             {
-                _lastConnection = Time.time;
+                _lastConnection = Time.unscaledTime;
                 if (_timerBackgroundWork || !BacktraceDatabaseContext.Any())
                 {
                     return;
@@ -206,7 +206,7 @@ namespace Backtrace.Unity
             RemoveOrphaned();
             if (DatabaseSettings.AutoSendMode)
             {
-                _lastConnection = Time.time;
+                _lastConnection = Time.unscaledTime;
                 SendData(BacktraceDatabaseContext.FirstOrDefault());
             }
         }

--- a/Runtime/BacktraceDatabase.cs
+++ b/Runtime/BacktraceDatabase.cs
@@ -174,7 +174,7 @@ namespace Backtrace.Unity
             {
                 return;
             }
-            LastFrameTime = Time.tiunscaledTimeme;
+            LastFrameTime = Time.unscaledTime;
             if (!DatabaseSettings.AutoSendMode)
             {
                 return;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "io.backtrace.unity",
   "displayName": "Backtrace",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "unity": "2017.1",
   "description": "Backtrace's integration with Unity games allows customers to capture and report handled and unhandled Unity exceptions to their Backtrace instance, instantly offering the ability to prioritize and debug software errors.",
   "keywords": [


### PR DESCRIPTION
# Backtrace Unity version 3.3.2

**Problem**
When user pause a game, `Time.time` value isn't updated by Unity engine. However, Backtrace's Unity Game object update method will be still called by Unity engine. 

Previously our ANR detection algorithm used `Time.time` value to determine game hangs. In the situation when game is paused, `Time.time` value isn't updated. To fix this issue Backrace-Unity has to use `Time.unscaledTime` to determine time elapsed since game startup that won't be stopped by game pauses.


## Testing strategy

### Bug reproduction
1. Pause game
2. Check Backtrace after ~10 seconds 
3. If report is available in Backtrace it means that we were able to reproduce issue


### Fix testing strategy

#### Shouldn't report ANR
- Pause game,
- Check if game reported ANR
**Result:** Game didn't report ANR


#### Should report ANR
- Pause a game,
- start ANR,
- Check if game reported ANR 
**Result:** Game reported ANR

#### Should report ANR
- Don't pause game,
- start ANR
- Check if game reported ANR
**Result:** Game reported ANR
