### PR TITLE
Version 3.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Backtrace Unity Release Notes
 
 ## Version 3.3.3
-- Fixed iOS compilation issue with Backtrace namespace,
-- Prevents from displaying Backtrace configuration when Application.isPlaying is true to avoid user mistakes.
+- Fixed iOS compilation issue with Backtrace namespace.
+- Prevent displaying Backtrace configuration when Application.isPlaying is true.
 
 ## Version 3.3.2
 - ANR detection algorithm now uses `Time.unscaledTime` instead of `Time.time` to prevent ANR detection when game is paused.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Backtrace Unity Release Notes
 
+## Version 3.3.3
+- Fixed iOS compilation issue with Backtrace namespace,
+- Prevents from displaying Backtrace configuration when Application.isPlaying is true to avoid user mistakes.
+
 ## Version 3.3.2
 - ANR detection algorithm now uses `Time.unscaledTime` instead of `Time.time` to prevent ANR detection when game is paused.
 

--- a/Editor/BacktraceClientEditor.cs
+++ b/Editor/BacktraceClientEditor.cs
@@ -9,6 +9,10 @@ namespace Backtrace.Unity.Editor
     {
         public override void OnInspectorGUI()
         {
+            if (Application.isPlaying)
+            { 
+                return;
+            }
             var component = (BacktraceClient)target;
             component.Configuration =
                 (BacktraceConfiguration)EditorGUILayout.ObjectField(

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -20,7 +20,7 @@ namespace Backtrace.Unity
     {
         public BacktraceConfiguration Configuration;
 
-        public const string VERSION = "3.3.2";
+        public const string VERSION = "3.3.3";
         public bool Enabled { get; private set; }
 
         /// <summary>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "io.backtrace.unity",
   "displayName": "Backtrace",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "unity": "2017.1",
   "description": "Backtrace's integration with Unity games allows customers to capture and report handled and unhandled Unity exceptions to their Backtrace instance, instantly offering the ability to prioritize and debug software errors.",
   "keywords": [


### PR DESCRIPTION
## Version 3.3.3
- Fixed iOS compilation issue with Backtrace namespace,
- Prevents from displaying Backtrace configuration when Application.isPlaying is true to avoid user mistakes.
