### PR TITLE
Optimize screenshot size and upload speed, allow for error logs to be filtered client side

### DIFF
--- a/Editor/BacktraceConfigurationEditor.cs
+++ b/Editor/BacktraceConfigurationEditor.cs
@@ -149,6 +149,14 @@ namespace Backtrace.Unity.Editor
                         serializedObject.FindProperty("GenerateScreenshotOnException"),
                         new GUIContent(BacktraceConfigurationLabels.LABEL_GENERATE_SCREENSHOT_ON_EXCEPTION));
 
+                    EditorGUILayout.PropertyField(
+                        serializedObject.FindProperty("ScreenshotMaxHeight"),
+                        new GUIContent(BacktraceConfigurationLabels.LABEL_GENERATE_SCREENSHOT_MAX_HEIGHT));
+
+                    EditorGUILayout.PropertyField(
+                        serializedObject.FindProperty("ScreenshotQuality"),
+                        new GUIContent(BacktraceConfigurationLabels.LABEL_GENERATE_SCREENSHOT_QUALITY));
+
                     SerializedProperty maxRecordCount = serializedObject.FindProperty("MaxRecordCount");
                     EditorGUILayout.PropertyField(maxRecordCount, new GUIContent(BacktraceConfigurationLabels.LABEL_MAX_REPORT_COUNT));
 

--- a/Editor/BacktraceConfigurationLabels.cs
+++ b/Editor/BacktraceConfigurationLabels.cs
@@ -34,6 +34,8 @@
         internal static string LABEL_MINIDUMP_SUPPORT = "Minidump type";
         internal static string LABEL_ADD_UNITY_LOG = "Attach Unity Player.log";
         internal static string LABEL_GENERATE_SCREENSHOT_ON_EXCEPTION = "Attach screenshot";
+        internal static string LABEL_GENERATE_SCREENSHOT_MAX_HEIGHT = "Screenshot max height";
+        internal static string LABEL_GENERATE_SCREENSHOT_QUALITY = "Screenshot quality";
         internal static string LABEL_DEDUPLICATION_RULES = "Client-Side deduplication";
         internal static string LABEL_AUTO_SEND_MODE = "Auto send mode";
         internal static string LABEL_CREATE_DATABASE_DIRECTORY = "Create database directory";

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -737,6 +737,10 @@ namespace Backtrace.Unity
             {
                 return;
             }
+
+            if (Configuration.ReportFilterType.HasFlag(ReportFilterType.Error) && type == LogType.Error)
+                return;
+
             var unityMessage = new BacktraceUnityMessage(message, stackTrace, type);
             _backtraceLogManager.Enqueue(unityMessage);
             if (Configuration.HandleUnhandledExceptions && unityMessage.IsUnhandledException())

--- a/Runtime/Model/BacktraceConfiguration.cs
+++ b/Runtime/Model/BacktraceConfiguration.cs
@@ -164,6 +164,18 @@ namespace Backtrace.Unity.Model
         public bool GenerateScreenshotOnException = false;
 
         /// <summary>
+        /// Generate game screen shot when exception happen
+        /// </summary>
+        [Tooltip("Max screenshot height default 720")]
+        public int ScreenshotMaxHeight = 720;
+
+        /// <summary>
+        /// Generate game screen shot when exception happen
+        /// </summary>
+        [Tooltip("Screenshot JPG quality 0-100, default 50")]
+        public int ScreenshotQuality = 50;
+
+        /// <summary>
         /// Directory path where reports and minidumps are stored
         /// </summary>
         [Tooltip("This is the path to directory where the Backtrace database will store reports on your game. NOTE: Backtrace database will remove all existing files on database start.")]

--- a/Runtime/Model/Database/BacktraceDatabaseAttachmentManager.cs
+++ b/Runtime/Model/Database/BacktraceDatabaseAttachmentManager.cs
@@ -98,22 +98,23 @@ namespace Backtrace.Unity.Model.Database
                     {
 
                         float ratio = (float)Screen.width / (float)Screen.height;
-
                         int targetHeight = Mathf.Min(Screen.height, _settings.ScreenshotMaxHeight);
                         int targetWidth = Mathf.RoundToInt((float)targetHeight * ratio);
 
-                        // Create a render texture to render into
-                        RenderTexture screenRT = RenderTexture.GetTemporary(Screen.width, Screen.height);
-
+#if UNITY_2019_1_OR_NEWER
+                        RenderTexture screenTexture = RenderTexture.GetTemporary(Screen.width, Screen.height);
                         ScreenCapture.CaptureScreenshotIntoRenderTexture(screenRT);
+#else
+                        Texture2D screenTexture = ScreenCapture.CaptureScreenshotAsTexture();
+#endif
 
                         // Create a render texture to render into
                         RenderTexture rt = RenderTexture.GetTemporary(targetWidth, targetHeight);
 
                         if (SystemInfo.graphicsUVStartsAtTop)
-                            Graphics.Blit(screenRT, rt, new Vector2(1.0f, -1.0f), new Vector2(0.0f, 1.0f));
+                            Graphics.Blit(screenTexture, rt, new Vector2(1.0f, -1.0f), new Vector2(0.0f, 1.0f));
                         else
-                            Graphics.Blit(screenRT, rt);
+                            Graphics.Blit(screenTexture, rt);
 
                         RenderTexture previousActiveRT = RenderTexture.active;
                         RenderTexture.active = rt;
@@ -128,7 +129,11 @@ namespace Backtrace.Unity.Model.Database
 
                         RenderTexture.ReleaseTemporary(rt);
 
-                        RenderTexture.ReleaseTemporary(screenRT);
+#if UNITY_2019_1_OR_NEWER
+                        RenderTexture.ReleaseTemporary(screenTexture);
+#else
+                        GameObject.Destroy(screenTexture);
+#endif
 
                         File.WriteAllBytes(screenshotPath, result.EncodeToJPG(_settings.ScreenshotQuality));
 

--- a/Runtime/Model/Database/BacktraceDatabaseSettings.cs
+++ b/Runtime/Model/Database/BacktraceDatabaseSettings.cs
@@ -104,7 +104,27 @@ namespace Backtrace.Unity.Model.Database
                 return _configuration.GenerateScreenshotOnException;
             }
         }
+        /// <summary>
+        /// Screenshot max height
+        /// </summary>
+        public int ScreenshotMaxHeight
+        {
+            get
+            {
+                return _configuration.ScreenshotMaxHeight;
+            }
+        }
 
+        /// <summary>
+        /// Screenshot quality
+        /// </summary>
+        public int ScreenshotQuality
+        {
+            get
+            {
+                return _configuration.ScreenshotQuality;
+            }
+        }
         /// <summary>
         /// Add Unity log file to Backtrace report
         /// </summary>

--- a/Runtime/Types/ReportFilterType.cs
+++ b/Runtime/Types/ReportFilterType.cs
@@ -44,6 +44,13 @@ namespace Backtrace.Unity.Types
         /// Game hang
         /// </summary>
         [Tooltip("Game hang.")]
-        Hang = 8
+        Hang = 8,
+
+        /// <summary>
+        /// Game hang
+        /// </summary>
+        [Tooltip("Debug.LogError")]
+        Error = 16
+
     }
 }


### PR DESCRIPTION
Reasons for the change

1. Screenshots are currently sitting between 500kb - 800kb on high end phones, this is going to quickly fill up storage.
2. Scaling screenshots on GPU and sending a smaller size file is likely faster even if JPG compression takes slightly longer due to upload time being significantly lower.
3. Using Unity's ScreepCapture API to ensure highest compatibility with UI
4. Sometimes you want to be able to stop Error logs from being reported as they aren't always important in all projects
