### PR TITLE
Detect false-positive ANRs report and prevent ANR watchdog from sending them

### DIFF
--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -426,7 +426,6 @@ namespace Backtrace.Unity
             Application.lowMemory -= HandleLowMemory;
             _nativeClient?.Disable();
 #endif
-
         }
 
         /// <summary>
@@ -704,6 +703,11 @@ namespace Backtrace.Unity
                 Application.lowMemory += HandleLowMemory;
 #endif
             }
+        }
+
+        internal void OnApplicationPause(bool pause)
+        {
+            _nativeClient?.PauseAnrThread(pause);
         }
 
 #if UNITY_ANDROID || UNITY_IOS

--- a/Runtime/Native/Android/NativeClient.cs
+++ b/Runtime/Native/Android/NativeClient.cs
@@ -20,9 +20,9 @@ namespace Backtrace.Unity.Runtime.Native.Android
 
         /// <summary>
         /// Determine if the ANR background thread should be disabled or not 
-        /// for some time of period.
+        /// for some period of time.
         /// This option will be used by the native client implementation
-        /// once applicaiton goes to background/foreground
+        /// once application goes to background/foreground
         /// </summary>
         volatile internal bool _preventAnr = false;
 
@@ -348,10 +348,10 @@ namespace Backtrace.Unity.Runtime.Native.Android
 
                         lastUpdatedCache = _lastUpdateTime;
                     }
-                    // make sure when ANR happened just after going to foreground
-                    // we won't false positive ANR report
                     else if (lastUpdatedCache != 0)
                     {
+                        // make sure when ANR happened just after going to foreground
+                        // we won't false positive ANR report
                         lastUpdatedCache = 0;
                     }
                     Thread.Sleep(5000);
@@ -417,7 +417,7 @@ namespace Backtrace.Unity.Runtime.Native.Android
         /// <summary>
         /// Pause ANR detection
         /// </summary>
-        /// <param name="stopAnr">True - if native client should pause an ANR detection</param>
+        /// <param name="stopAnr">True - if native client should pause ANR detection"</param>
         public void PauseAnrThread(bool stopAnr)
         {
             _preventAnr = stopAnr;

--- a/Runtime/Native/Android/NativeClient.cs
+++ b/Runtime/Native/Android/NativeClient.cs
@@ -16,7 +16,20 @@ namespace Backtrace.Unity.Runtime.Native.Android
     internal class NativeClient : INativeClient
     {
         // Last Backtrace client update time 
-        internal float _lastUpdateTime;
+        volatile internal float _lastUpdateTime;
+
+        /// <summary>
+        /// Determine if the ANR background thread should be disabled or not 
+        /// for some time of period.
+        /// This option will be used by the native client implementation
+        /// once applicaiton goes to background/foreground
+        /// </summary>
+        volatile internal bool _preventAnr = false;
+
+        /// <summary>
+        /// Determine if ANR thread should exit
+        /// </summary>
+        volatile internal bool _stopAnr = false;
 
         private Thread _anrThread;
 
@@ -301,42 +314,50 @@ namespace Backtrace.Unity.Runtime.Native.Android
             _anrThread = new Thread(() =>
             {
                 float lastUpdatedCache = 0;
-                while (true)
+                while (_anrThread.IsAlive && _stopAnr == false)
                 {
-                    if (lastUpdatedCache == 0)
+                    if (!_preventAnr)
                     {
-                        lastUpdatedCache = _lastUpdateTime;
-                    }
-                    else if (lastUpdatedCache == _lastUpdateTime)
-                    {
-                        if (!reported)
+                        if (lastUpdatedCache == 0)
                         {
-
-                            reported = true;
-                            if (AndroidJNI.AttachCurrentThread() == 0)
+                            lastUpdatedCache = _lastUpdateTime;
+                        }
+                        else if (lastUpdatedCache == _lastUpdateTime)
+                        {
+                            if (!reported)
                             {
-                                // set temporary attribute to "Hang"
-                                AddAttribute(
-                                    AndroidJNI.NewStringUTF("error.type"),
-                                    AndroidJNI.NewStringUTF("Hang"));
 
-                                NativeReport(AndroidJNI.NewStringUTF("ANRException: Blocked thread detected."));
-                                // update error.type attribute in case when crash happen 
-                                SetAttribute("error.type", "Crash");
+                                reported = true;
+                                if (AndroidJNI.AttachCurrentThread() == 0)
+                                {
+                                    // set temporary attribute to "Hang"
+                                    AddAttribute(
+                                        AndroidJNI.NewStringUTF("error.type"),
+                                        AndroidJNI.NewStringUTF("Hang"));
+
+                                    NativeReport(AndroidJNI.NewStringUTF("ANRException: Blocked thread detected."));
+                                    // update error.type attribute in case when crash happen 
+                                    SetAttribute("error.type", "Crash");
+                                }
                             }
                         }
+                        else
+                        {
+                            reported = false;
+                        }
+
+                        lastUpdatedCache = _lastUpdateTime;
                     }
-                    else
+                    // make sure when ANR happened just after going to foreground
+                    // we won't false positive ANR report
+                    else if (lastUpdatedCache != 0)
                     {
-                        reported = false;
+                        lastUpdatedCache = 0;
                     }
-
-                    lastUpdatedCache = _lastUpdateTime;
                     Thread.Sleep(5000);
-
                 }
             });
-
+            _anrThread.IsBackground = true;
             _anrThread.Start();
         }
 
@@ -389,8 +410,17 @@ namespace Backtrace.Unity.Runtime.Native.Android
         {
             if (_anrThread != null)
             {
-                _anrThread.Abort();
+                _stopAnr = true;
             }
+        }
+
+        /// <summary>
+        /// Pause ANR detection
+        /// </summary>
+        /// <param name="stopAnr">True - if native client should pause an ANR detection</param>
+        public void PauseAnrThread(bool stopAnr)
+        {
+            _preventAnr = stopAnr;
         }
     }
 }

--- a/Runtime/Native/INativeClient.cs
+++ b/Runtime/Native/INativeClient.cs
@@ -40,5 +40,11 @@ namespace Backtrace.Unity.Runtime.Native
         /// Disable native integration
         /// </summary>
         void Disable();
+
+        /// <summary>
+        /// Pause ANR thread
+        /// </summary>
+        /// <param name="state">True if should pause, otherwise false.</param>
+        void PauseAnrThread(bool state);
     }
 }

--- a/Runtime/Native/iOS/NativeClient.cs
+++ b/Runtime/Native/iOS/NativeClient.cs
@@ -20,9 +20,9 @@ namespace Backtrace.Unity.Runtime.Native.iOS
 
         /// <summary>
         /// Determine if the ANR background thread should be disabled or not 
-        /// for some time of period.
+        /// for some period of time.
         /// This option will be used by the native client implementation
-        /// once applicaiton goes to background/foreground
+        /// once application goes to background/foreground
         /// </summary>
         volatile internal bool _preventAnr = false;
 
@@ -180,10 +180,10 @@ namespace Backtrace.Unity.Runtime.Native.iOS
 
                         lastUpdatedCache = _lastUpdateTime;
                     }
-                    // make sure when ANR happened just after going to foreground
-                    // we won't false positive ANR report
                     else if (lastUpdatedCache != 0)
                     {
+                        // make sure when ANR happened just after going to foreground
+                        // we won't false positive ANR report
                         lastUpdatedCache = 0;
                     }
                     Thread.Sleep(5000);
@@ -258,7 +258,7 @@ namespace Backtrace.Unity.Runtime.Native.iOS
         /// <summary>
         /// Pause ANR detection
         /// </summary>
-        /// <param name="stopAnr">True - if native client should pause an ANR detection</param>
+        /// <param name="stopAnr">True - if native client should pause ANR detection"</param>
         public void PauseAnrThread(bool stopAnr)
         {
             _preventAnr = stopAnr;


### PR DESCRIPTION
# Why

When the user closed an application just after the ANR watchdog ANR check, the next time when an application goes from background to foreground, the ANR watchdog might report a false-positive ANR. To prevent this situation we need to also detect when an application goes to background/foreground and prevent/allow ANR checks depends on the application state.


# Technical background
* Game objects update method works only when an application is in the foreground, however, our ANR watchdog background thread is able to compare main/background thread time even when an application goes to background. In this situation when an application goes to the background just after ANR check and before any update method, we will report an ANR situation. When an application goes to foreground/background the `nativeClient` instance sets `_preventAnr` flag to false/true.
* This patch also contains few improvements 
  - we need to be sure that ANR watchdog uses the most recent time available in the main thread - because of that we changed Update to LateUpdate
  - to avoid ThreadAbortExecption we started comparing thread state instead of just aborting thread - long story short, this answer contains all needed resources to read about it: https://stackoverflow.com/a/19048316/4818730
  - to prevent reporting ANR when an application goes from background to thread, the nativeClient instance set lastUpdatedTime to 0 - which algorithm will treat like a starting point for detecting ANRs.

# Testing strategy
**Move application to background on Android/iOS just after ANR detection method and wait more than 5 seconds**
- previously this use case report an ANR
- now it doesn't 
- tested only manually on Android device/iOS simulator

No unit tests.

# Commercialization
This diff will be merged to branch release/3.3.4. After merging all technical changes we will work on the documentation/changelog improvements.