### PR TITLE
Changes to make adhoc custom breadcrumbs possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 
 [Backtrace](http://backtrace.io/)'s integration with Unity allows developers to capture and report log errors, handled and unhandled Unity exceptions, and native crashes to their Backtrace instance, instantly offering the ability to prioritize and debug software errors.
 
+Create your Backtrace instance at https://backtrace.io/create-unity today and then integrate this library into your game.
+
 [![openupm](https://img.shields.io/npm/v/io.backtrace.unity?label=openupm&registry_uri=https://package.openupm.com)](https://openupm.com/packages/io.backtrace.unity/)
 
 

--- a/Runtime/Services/BacktraceApi.cs
+++ b/Runtime/Services/BacktraceApi.cs
@@ -123,7 +123,7 @@ namespace Backtrace.Unity.Services
                 if (File.Exists(file) && new FileInfo(file).Length < 10000000)
                 {
                     formData.Add(new MultipartFormFileSection(
-                        string.Format("attachment__{0}", Path.GetFileName(file)),
+                        string.Format("attachment_{0}", Path.GetFileName(file)),
                         File.ReadAllBytes(file)));
                 }
             }
@@ -231,7 +231,7 @@ namespace Backtrace.Unity.Services
                 if (File.Exists(file) && new FileInfo(file).Length < 10000000)
                 {
                     formData.Add(new MultipartFormFileSection(
-                        string.Format("attachment__{0}", Path.GetFileName(file)),
+                        string.Format("attachment_{0}", Path.GetFileName(file)),
                         File.ReadAllBytes(file)));
                 }
             }


### PR DESCRIPTION
See [here](https://github.com/vlussenburg/asterax/commit/5ff53d44fa5f50a0e9b58c5b45294e7f266d5ab6)

Breadcrumbs attachments need to be uploaded without a prefix `_` - Backtrace won't recognize them otherwise.