### PR TITLE
Changes to make adhoc custom breadcrumbs possible

### DIFF
--- a/Runtime/Services/BacktraceApi.cs
+++ b/Runtime/Services/BacktraceApi.cs
@@ -124,7 +124,7 @@ namespace Backtrace.Unity.Services
                 if (File.Exists(file) && new FileInfo(file).Length < 10000000)
                 {
                     formData.Add(new MultipartFormFileSection(
-                        string.Format("attachment__{0}", Path.GetFileName(file)),
+                        string.Format("attachment_{0}", Path.GetFileName(file)),
                         File.ReadAllBytes(file)));
                 }
             }
@@ -232,7 +232,7 @@ namespace Backtrace.Unity.Services
                 if (File.Exists(file) && new FileInfo(file).Length < 10000000)
                 {
                     formData.Add(new MultipartFormFileSection(
-                        string.Format("attachment__{0}", Path.GetFileName(file)),
+                        string.Format("attachment_{0}", Path.GetFileName(file)),
                         File.ReadAllBytes(file)));
                 }
             }


### PR DESCRIPTION
For some reason (line ending?) the commit looks huge but that was changed is:

`attachment__` to `attachment_` (single underscore)

Backtrace doesn't recognize `_bt-breacrumbs-0`.. needed to get rid of that underscore.