### PR TITLE
Event aggregation logic for reviewers

### DIFF
--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -465,7 +465,7 @@ namespace Backtrace.Unity
             }
         }
 
-        public void EnableSessionAgregationSupport(string submissionUrl, long timeIntervalInMs, int maximumNumberOfEventsInStore)
+        public void EnableSessionAgregationSupport(string submissionUrl, long timeIntervalInMs, uint maximumNumberOfEventsInStore)
         {
             if (Session != null)
             {

--- a/Runtime/Common/MathHelper.cs
+++ b/Runtime/Common/MathHelper.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Backtrace.Unity.Common
+{
+    internal static class MathHelper
+    {
+        public static double Clamp(double value, double minimum, double maximum)
+        {
+            return Math.Max(minimum, Math.Min(maximum, value));
+        }
+
+        public static double Uniform(double minimum, double maximum)
+        {
+            return new System.Random().NextDouble() * (maximum - minimum) + minimum;
+        }
+    }
+}

--- a/Runtime/Common/MathHelper.cs.meta
+++ b/Runtime/Common/MathHelper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4903fe888cfc0c44b9ea65544b50eb5d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Interfaces/IBacktraceSession.cs
+++ b/Runtime/Interfaces/IBacktraceSession.cs
@@ -6,7 +6,7 @@ namespace Backtrace.Unity.Interfaces
     {
         string SubmissionUrl { get; set; }
         void Send();
-        bool AddUniqueEventAttribute(string attributeName, IDictionary<string, string> attributes);
+        bool AddUniqueEvent(string attributeName, IDictionary<string, string> attributes);
         bool AddSessionEvent(string sessionEvent, IDictionary<string, string> attributes);
         void Tick(long time);
     }

--- a/Runtime/Interfaces/IBacktraceSession.cs
+++ b/Runtime/Interfaces/IBacktraceSession.cs
@@ -5,6 +5,7 @@ namespace Backtrace.Unity.Interfaces
     public interface IBacktraceSession
     {
         string SubmissionUrl { get; set; }
+        void SendStartupEvent();
         void Send();
         bool AddUniqueEvent(string attributeName, IDictionary<string, string> attributes);
         bool AddSessionEvent(string sessionEvent, IDictionary<string, string> attributes);

--- a/Runtime/Interfaces/IBacktraceSession.cs
+++ b/Runtime/Interfaces/IBacktraceSession.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+
+namespace Backtrace.Unity.Interfaces
+{
+    public interface IBacktraceSession
+    {
+        string SubmissionUrl { get; set; }
+        void Send();
+        bool AddUniqueEventAttribute(string attributeName, IDictionary<string, string> attributes);
+        bool AddSessionEvent(string sessionEvent, IDictionary<string, string> attributes);
+        void Tick(long time);
+    }
+}

--- a/Runtime/Interfaces/IBacktraceSession.cs
+++ b/Runtime/Interfaces/IBacktraceSession.cs
@@ -9,6 +9,6 @@ namespace Backtrace.Unity.Interfaces
         void Send();
         bool AddUniqueEvent(string attributeName, IDictionary<string, string> attributes);
         bool AddSessionEvent(string sessionEvent, IDictionary<string, string> attributes);
-        void Tick(long time);
+        void Tick(float time);
     }
 }

--- a/Runtime/Interfaces/IBacktraceSession.cs.meta
+++ b/Runtime/Interfaces/IBacktraceSession.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4a288324b25ec2f419a5d3017bf69bd3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Model/Session/EventAggregationBase.cs
+++ b/Runtime/Model/Session/EventAggregationBase.cs
@@ -1,0 +1,26 @@
+﻿using Backtrace.Unity.Json;
+using System.Collections.Generic;
+
+namespace Backtrace.Unity.Model.Session
+{
+    internal abstract class EventAggregationBase
+    {
+        private const string TimestampName = "timestamp";
+        private const string AttributesName = "attributes";
+        public long Timestamp { get; set; }
+        public string Name { get; private set; }
+        public EventAggregationBase(string name, long timestamp)
+        {
+            Name = name;
+            Timestamp = timestamp;
+        }
+
+        internal BacktraceJObject ToBaseObject(IDictionary<string, string> attributes)
+        {
+            var jObject = new BacktraceJObject();
+            jObject.Add(TimestampName, Timestamp);
+            jObject.Add(AttributesName, new BacktraceJObject(attributes));
+            return jObject;
+        }
+    }
+}

--- a/Runtime/Model/Session/EventAggregationBase.cs.meta
+++ b/Runtime/Model/Session/EventAggregationBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 97162ef11f02a3a4789892fc02999b46
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Model/Session/SessionEvent.cs
+++ b/Runtime/Model/Session/SessionEvent.cs
@@ -1,0 +1,30 @@
+﻿using Backtrace.Unity.Json;
+using System.Collections.Generic;
+
+namespace Backtrace.Unity.Model.Session
+{
+    internal sealed class SessionEvent : EventAggregationBase
+    {
+        internal const string MetircsGroupName = "metric_group";
+        internal readonly IDictionary<string, string> Attributes;
+        internal SessionEvent(string name, long timestamp, IDictionary<string, string> attributes) : base(name, timestamp)
+        {
+            Attributes = attributes;
+        }
+
+        internal BacktraceJObject ToJson(IDictionary<string, string> attributes)
+        {
+            if (Attributes != null)
+            {
+                foreach (var attribute in Attributes)
+                {
+                    attributes[attribute.Key] = attribute.Value;
+                }
+            }
+            var jObject = ToBaseObject(attributes);
+            jObject.Add(MetircsGroupName, Name);
+
+            return jObject;
+        }
+    }
+}

--- a/Runtime/Model/Session/SessionEvent.cs
+++ b/Runtime/Model/Session/SessionEvent.cs
@@ -5,7 +5,7 @@ namespace Backtrace.Unity.Model.Session
 {
     internal sealed class SessionEvent : EventAggregationBase
     {
-        internal const string MetircsGroupName = "metric_group";
+        internal const string MetricGroupName = "metric_group";
         internal readonly IDictionary<string, string> Attributes;
         internal SessionEvent(string name, long timestamp, IDictionary<string, string> attributes) : base(name, timestamp)
         {
@@ -22,7 +22,7 @@ namespace Backtrace.Unity.Model.Session
                 }
             }
             var jObject = ToBaseObject(attributes);
-            jObject.Add(MetircsGroupName, Name);
+            jObject.Add(MetricGroupName, Name);
 
             return jObject;
         }

--- a/Runtime/Model/Session/SessionEvent.cs
+++ b/Runtime/Model/Session/SessionEvent.cs
@@ -1,4 +1,5 @@
-﻿using Backtrace.Unity.Json;
+﻿using Backtrace.Unity.Common;
+using Backtrace.Unity.Json;
 using System.Collections.Generic;
 
 namespace Backtrace.Unity.Model.Session
@@ -7,6 +8,9 @@ namespace Backtrace.Unity.Model.Session
     {
         internal const string MetricGroupName = "metric_group";
         internal readonly IDictionary<string, string> Attributes;
+        internal SessionEvent(string name) : this(name, DateTimeHelper.Timestamp(), new Dictionary<string, string>())
+        { }
+
         internal SessionEvent(string name, long timestamp, IDictionary<string, string> attributes) : base(name, timestamp)
         {
             Attributes = attributes;

--- a/Runtime/Model/Session/SessionEvent.cs.meta
+++ b/Runtime/Model/Session/SessionEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1488838b757c9944bbeca58d16e6c1d6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Model/Session/SessionSubmissionJob.cs
+++ b/Runtime/Model/Session/SessionSubmissionJob.cs
@@ -5,6 +5,6 @@
         public double NextInvokeTime { get; set; }
         public UniqueEvent[] UniqueEvents { get; set; }
         public SessionEvent[] SessionEvents { get; set; }
-        public uint NumberOfRetries { get; set; }
+        public uint NumberOfAttemps { get; set; }
     }
 }

--- a/Runtime/Model/Session/SessionSubmissionJob.cs
+++ b/Runtime/Model/Session/SessionSubmissionJob.cs
@@ -1,0 +1,10 @@
+﻿namespace Backtrace.Unity.Model.Session
+{
+    internal sealed class SessionSubmissionJob
+    {
+        public float NextInvokeTime { get; set; }
+        public UniqueEvent[] UniqueEvents { get; set; }
+        public SessionEvent[] SessionEvents { get; set; }
+        public uint NumberOfRetries { get; set; }
+    }
+}

--- a/Runtime/Model/Session/SessionSubmissionJob.cs
+++ b/Runtime/Model/Session/SessionSubmissionJob.cs
@@ -2,7 +2,7 @@
 {
     internal sealed class SessionSubmissionJob
     {
-        public float NextInvokeTime { get; set; }
+        public double NextInvokeTime { get; set; }
         public UniqueEvent[] UniqueEvents { get; set; }
         public SessionEvent[] SessionEvents { get; set; }
         public uint NumberOfRetries { get; set; }

--- a/Runtime/Model/Session/SessionSubmissionJob.cs.meta
+++ b/Runtime/Model/Session/SessionSubmissionJob.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5baffda7a637394479b48cba8b598180
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Model/Session/UniqueEvent.cs
+++ b/Runtime/Model/Session/UniqueEvent.cs
@@ -1,0 +1,25 @@
+﻿using Backtrace.Unity.Json;
+using System.Collections.Generic;
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Backtrace.Unity.Tests.Runtime")]
+namespace Backtrace.Unity.Model.Session
+{
+    internal sealed class UniqueEvent : EventAggregationBase
+    {
+        internal const string UniqueEventName = "unique";
+        internal readonly IDictionary<string, string> Attributes;
+        internal UniqueEvent(
+            string name, 
+            long timestamp, 
+            IDictionary<string, string> attributes) : base(name, timestamp)
+        {
+            Attributes = attributes;
+        }
+
+        internal BacktraceJObject ToJson()
+        {
+            var jObject = ToBaseObject(Attributes);
+            jObject.Add(UniqueEventName, new string[1] { Name });
+            return jObject;
+        }
+    }
+}

--- a/Runtime/Model/Session/UniqueEvent.cs.meta
+++ b/Runtime/Model/Session/UniqueEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9f4f4058db1dd0c45b664aa2cc80ffa6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Services/BacktraceSession.cs
+++ b/Runtime/Services/BacktraceSession.cs
@@ -285,7 +285,7 @@ namespace Backtrace.Unity.Services
                     {
                         UniqueEvents = uniqueEvents,
                         SessionEvents = sessionEvents,
-                        NextInvokeTime = CalculateNextRetryTime(MaxNumberOfAttemps - attemps),
+                        NextInvokeTime = CalculateNextRetryTime(attemps + 1),
                         NumberOfAttemps = attemps + 1
                     });
 

--- a/Runtime/Services/BacktraceSession.cs
+++ b/Runtime/Services/BacktraceSession.cs
@@ -64,7 +64,7 @@ namespace Backtrace.Unity.Services
         /// Maximum number of events in store. If number of events in store hit the limit
         /// BacktraceSession instance will send data to Backtrace.
         /// </summary>
-        private int _maximumNumberOfEventsInStore;
+        private uint _maximumNumberOfEventsInStore;
 
         /// <summary>
         /// Http client
@@ -93,7 +93,7 @@ namespace Backtrace.Unity.Services
             AttributeProvider attributeProvider,
             string uploadUrl,
             long timeIntervalInMs,
-            int maximumNumberOfEventsInStore)
+            uint maximumNumberOfEventsInStore)
         {
             SubmissionUrl = uploadUrl;
             _attributeProvider = attributeProvider;
@@ -108,10 +108,14 @@ namespace Backtrace.Unity.Services
         /// <param name="time">Current game time</param>
         public void Tick(long time)
         {
+            if (_timeIntervalInMs == 0)
+            {
+                return;
+            }
             lock (_object)
             {
                 var intervalUpdate = (time - _lastUpdateTime) >= _timeIntervalInMs;
-                var reachedEventLimit = _maximumNumberOfEventsInStore == Count();
+                var reachedEventLimit = _maximumNumberOfEventsInStore == Count() && _maximumNumberOfEventsInStore != 0;
                 if (intervalUpdate == false && reachedEventLimit == false)
                 {
                     // nothing more to update
@@ -212,7 +216,7 @@ namespace Backtrace.Unity.Services
         /// <returns>True if we're able to add. Otherwise false.</returns>
         private bool ShouldProcessEvent(string name)
         {
-            return !string.IsNullOrEmpty(name) && (Count() + 1 <= _maximumNumberOfEventsInStore);
+            return !string.IsNullOrEmpty(name) && (_maximumNumberOfEventsInStore == 0 || (Count() + 1 <= _maximumNumberOfEventsInStore));
         }
 
 

--- a/Runtime/Services/BacktraceSession.cs
+++ b/Runtime/Services/BacktraceSession.cs
@@ -1,0 +1,313 @@
+﻿using Backtrace.Unity.Common;
+using Backtrace.Unity.Interfaces;
+using Backtrace.Unity.Json;
+using Backtrace.Unity.Model;
+using Backtrace.Unity.Model.JsonData;
+using Backtrace.Unity.Model.Session;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Backtrace.Unity.Tests.Runtime")]
+namespace Backtrace.Unity.Services
+{
+    internal sealed class BacktraceSession : IBacktraceSession
+    {
+        /// <summary>
+        /// Default number of retries
+        /// </summary>
+        public const int DefaultNumberOfRetries = 3;
+
+        /// <summary>
+        /// Submission url
+        /// </summary>
+        public string SubmissionUrl { get; set; }
+
+        /// <summary>
+        /// Determine if http client should ignore ssl validation
+        /// </summary>
+        public bool IgnoreSslValidation
+        {
+            get
+            {
+                return RequestHandler.IgnoreSslValidation;
+            }
+            set
+            {
+                RequestHandler.IgnoreSslValidation = value;
+            }
+        }
+
+        private int _numberOfDroppedEvents = 0;
+
+        /// <summary>
+        /// List of unique events that will be added to next session submission payload
+        /// </summary>
+        internal readonly LinkedList<UniqueEvent> UniqueEvents = new LinkedList<UniqueEvent>();
+
+        /// <summary>
+        /// List of session events that will be added to next session submission payload
+        /// </summary>
+        internal readonly LinkedList<SessionEvent> SessionEvents = new LinkedList<SessionEvent>();
+
+        /// <summary>
+        /// Time interval in ms that algorithm uses to automatically send data to Backtrace
+        /// </summary>
+        private readonly long _timeIntervalInMs;
+
+        /// <summary>
+        /// Last update time that will be updated after each update start
+        /// </summary>
+        private long _lastUpdateTime = 0;
+
+        /// <summary>
+        /// Maximum number of events in store. If number of events in store hit the limit
+        /// BacktraceSession instance will send data to Backtrace.
+        /// </summary>
+        private int _maximumNumberOfEventsInStore;
+
+        /// <summary>
+        /// Http client
+        /// </summary>
+        internal IBacktraceHttpClient RequestHandler;
+
+        /// <summary>
+        /// Backtrace attribute provider - shared reference that will be reused by Backtrace client to generate attributes.
+        /// BacktraceSession implementation uses attribute provider to generate attributes dynamically when user adds a session events.
+        /// </summary>
+        private readonly AttributeProvider _attributeProvider;
+
+        /// <summary>
+        /// Lock object
+        /// </summary>
+        private object _object = new object();
+
+        /// <summary>
+        /// Create new Backtrace session instance
+        /// </summary>
+        /// <param name="attributeProvider">Backtrace client attribute provider</param>
+        /// <param name="uploadUrl">Upload URL</param>
+        /// <param name="timeIntervalInMs">Update time interval in MS</param>
+        /// <param name="maximumNumberOfEventsInStore">Determine how many events we can store in event store</param>
+        public BacktraceSession(
+            AttributeProvider attributeProvider,
+            string uploadUrl,
+            long timeIntervalInMs,
+            int maximumNumberOfEventsInStore)
+        {
+            SubmissionUrl = uploadUrl;
+            _attributeProvider = attributeProvider;
+            _maximumNumberOfEventsInStore = maximumNumberOfEventsInStore;
+            _timeIntervalInMs = timeIntervalInMs;
+            RequestHandler = new BacktraceHttpClient();
+        }
+
+        /// <summary>
+        /// Backtrace session update interval method used by Backtrace client to update session events time
+        /// </summary>
+        /// <param name="time">Current game time</param>
+        public void Tick(long time)
+        {
+            lock (_object)
+            {
+                var intervalUpdate = (time - _lastUpdateTime) >= _timeIntervalInMs;
+                var reachedEventLimit = _maximumNumberOfEventsInStore == Count();
+                if (intervalUpdate == false && reachedEventLimit == false)
+                {
+                    // nothing more to update
+                    return;
+                }
+                _lastUpdateTime = time;
+            }
+            Send();
+        }
+
+        /// <summary>
+        /// Force BacktraceSession to Send data to Backtrace
+        /// </summary>
+        public void Send()
+        {
+            Send(numberOfRetries: 3);
+        }
+
+        /// <summary>
+        /// Force BacktraceSession to Send data to Backtrace with retry settings
+        /// </summary>
+        public void Send(int numberOfRetries = DefaultNumberOfRetries)
+        {
+            if (numberOfRetries == 0)
+            {
+                Debug.LogWarning("Backtrace Session: Cannot send session data to Backtrace due to submission issue.");
+                CleanEvents();
+                return;
+            }
+            if (Count() == 0)
+            {
+                return;
+            }
+            // create a copy of events 
+            var uniqueEvents = UniqueEvents.ToArray();
+            var sessionEvents = SessionEvents.ToArray();
+            var payload = CreateJsonPayload(uniqueEvents, sessionEvents);
+
+            // cleanup existing copy of events
+            CleanEvents();
+
+            // submit data to Backtrace
+            RequestHandler.Post(SubmissionUrl, payload, (long statusCode, bool httpError, string response) =>
+            {
+                if (statusCode == 200)
+                {
+                    OnRequestCompleted();
+                }
+                else
+                {
+                    OnRequestFailure(uniqueEvents, sessionEvents);
+                    // assume that we should try to retry request on 503
+                    Send(numberOfRetries - 1);
+                }
+            });
+        }
+
+        /// <summary>
+        /// Add unique event to next Backtrace session request
+        /// </summary>
+        /// <param name="attributeName">attribute name</param>
+        public bool AddUniqueEventAttribute(string attributeName, IDictionary<string, string> attributes = null)
+        {
+            if (!ShouldProcessEvent(attributeName))
+            {
+                Debug.LogWarning("Skipping report: Reached store limit or event has empty name.");
+                return false;
+            }
+            // add to event attributes, attribute provider attributes
+            if (attributes == null)
+            {
+                attributes = new Dictionary<string, string>();
+            }
+            _attributeProvider.AddAttributes(attributes);
+
+            // validate if unique event attribute is available and
+            // prevent undefined attributes
+            if (attributes.TryGetValue(attributeName, out string attributeValue) == false || string.IsNullOrEmpty(attributeValue))
+            {
+                Debug.LogWarning("Attribute name is not available in attribute scope. Please define attribute to set unique event.");
+                return false;
+            }
+            var existingEvent = UniqueEvents.FirstOrDefault(m => m.Name == attributeName);
+            if (existingEvent != null)
+            {
+                UniqueEvents.Remove(existingEvent);
+            }
+
+            var @event = new UniqueEvent(attributeName, DateTimeHelper.Timestamp(), attributes);
+            UniqueEvents.AddLast(@event);
+            return true;
+        }
+
+        /// <summary>
+        /// Determine if Backtrace Session can add next event to store
+        /// </summary>
+        /// <param name="name">event name</param>
+        /// <returns>True if we're able to add. Otherwise false.</returns>
+        private bool ShouldProcessEvent(string name)
+        {
+            return !string.IsNullOrEmpty(name) && (Count() + 1 <= _maximumNumberOfEventsInStore);
+        }
+
+
+        /// <summary>
+        /// Get number of events available right now in store
+        /// </summary>
+        /// <returns>number of events in store</returns>
+        public int Count()
+        {
+            return UniqueEvents.Count + SessionEvents.Count;
+        }
+
+        /// <summary>
+        /// Add session event to next Backtrace session request
+        /// </summary>
+        /// <param name="eventName">session event name</param>
+        public bool AddSessionEvent(string eventName, IDictionary<string, string> attributes = null)
+        {
+            if (!ShouldProcessEvent(eventName))
+            {
+                Debug.LogWarning("Skipping report: Reached store limit or event has empty name.");
+                return false;
+            }
+            var existingEvent = SessionEvents.FirstOrDefault(m => m.Name == eventName);
+            if (existingEvent != null)
+            {
+                SessionEvents.Remove(existingEvent);
+            }
+
+            var @event = new SessionEvent(eventName, DateTimeHelper.Timestamp(), attributes);
+            SessionEvents.AddLast(@event);
+            return true;
+        }
+
+        /// <summary>
+        /// Clean unique and session events stored in Backtrace Session
+        /// </summary>
+        public void CleanEvents()
+        {
+            UniqueEvents.Clear();
+            SessionEvents.Clear();
+        }
+
+        private void OnRequestCompleted()
+        {
+            _numberOfDroppedEvents = 0;
+            return;
+        }
+
+        private void OnRequestFailure(ICollection<UniqueEvent> uniqueEvents, ICollection<SessionEvent> sessionEvents)
+        {
+            _numberOfDroppedEvents++;
+            foreach (var uniqueEvent in uniqueEvents)
+            {
+                UniqueEvents.AddFirst(uniqueEvent);
+            }
+            foreach (var sessionEvent in sessionEvents)
+            {
+                SessionEvents.AddFirst(sessionEvent);
+            }
+        }
+
+        private BacktraceJObject CreateJsonPayload(ICollection<UniqueEvent> uniqueEvents, ICollection<SessionEvent> sessionEvents)
+        {
+            var jsonData = new BacktraceJObject();
+            jsonData.Add("application", Application.productName);
+            jsonData.Add("appversion", Application.version);
+            jsonData.Add("metadata", CreatePayloadMetadata());
+
+            // add unique events
+            var uniqueEventsJson = new List<BacktraceJObject>();
+            foreach (var uniqueEvent in uniqueEvents)
+            {
+                uniqueEventsJson.Add(uniqueEvent.ToJson());
+            }
+
+            jsonData.Add("unique_events", uniqueEventsJson);
+
+            // add unique events
+            var sessionEventsJson = new List<BacktraceJObject>();
+            var attributes = _attributeProvider.Get();
+            foreach (var sessionEvent in sessionEvents)
+            {
+                sessionEventsJson.Add(sessionEvent.ToJson(attributes));
+            }
+
+            jsonData.Add("session_events", sessionEventsJson);
+            return jsonData;
+        }
+
+        private BacktraceJObject CreatePayloadMetadata()
+        {
+            var payload = new BacktraceJObject();
+            payload.Add("dropped_events", _numberOfDroppedEvents);
+            return payload;
+        }
+    }
+}

--- a/Runtime/Services/BacktraceSession.cs
+++ b/Runtime/Services/BacktraceSession.cs
@@ -322,7 +322,7 @@ namespace Backtrace.Unity.Services
 
             jsonData.Add("unique_events", uniqueEventsJson);
 
-            // add unique events
+            // add session events
             var sessionEventsJson = new List<BacktraceJObject>();
             var attributes = _attributeProvider.Get();
             foreach (var sessionEvent in sessionEvents)

--- a/Runtime/Services/BacktraceSession.cs
+++ b/Runtime/Services/BacktraceSession.cs
@@ -14,6 +14,11 @@ namespace Backtrace.Unity.Services
     internal sealed class BacktraceSession : IBacktraceSession
     {
         /// <summary>
+        /// Startup event name that will be send on the application startup
+        /// </summary>
+        private const string StartupEventName = "Application Launches";
+
+        /// <summary>
         /// Default number of retries
         /// </summary>
         public const int DefaultNumberOfRetries = 3;
@@ -100,6 +105,14 @@ namespace Backtrace.Unity.Services
             _maximumNumberOfEventsInStore = maximumNumberOfEventsInStore;
             _timeIntervalInMs = timeIntervalInMs;
             RequestHandler = new BacktraceHttpClient();
+        }
+
+        /// <summary>
+        /// Send startup event ot Backtrace
+        /// </summary>
+        public void SendStartupEvent()
+        {
+            Send(new UniqueEvent[0], new SessionEvent[1] { new SessionEvent(StartupEventName) }, DefaultNumberOfRetries);
         }
 
         /// <summary>

--- a/Runtime/Services/BacktraceSession.cs
+++ b/Runtime/Services/BacktraceSession.cs
@@ -200,7 +200,7 @@ namespace Backtrace.Unity.Services
                 {
                     OnRequestCompleted();
                 }
-                else /*if (statusCode == 503)*/
+                else if (statusCode == 503)
                 {
                     _numberOfDroppedRequests++;
                     if (numberOfRetries - 1 != 0)

--- a/Runtime/Services/BacktraceSession.cs.meta
+++ b/Runtime/Services/BacktraceSession.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: be44b3b4cd99cf7438bd5063c8b6a7fb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/Session.meta
+++ b/Tests/Runtime/Session.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9b53a8bdb88c8e24b9535af48c7d4519
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/Session/BacktraceSessionTests.cs
+++ b/Tests/Runtime/Session/BacktraceSessionTests.cs
@@ -1,0 +1,257 @@
+﻿using Backtrace.Unity.Json;
+using Backtrace.Unity.Model.JsonData;
+using Backtrace.Unity.Services;
+using Backtrace.Unity.Tests.Runtime.Session.Mocks;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace Backtrace.Unity.Tests.Runtime.Session
+{
+    public class BacktraceSessionTests
+    {
+        const string SessionEventName = "scene-changed";
+        // existing attribute name in Backtrace
+        const string UniqueAttributeName = "scene.name";
+        private const string _submissionUrl = "https://event-edge.backtrace.io/api/user-aggregation/events?token=TOKEN";
+        private AttributeProvider _attributeProvider = new AttributeProvider();
+
+        [Test]
+        public void BacktraceSession_ShouldTriggerUploadProcessOnSendMethodWithOnlySessionEvent_DataWasSendToTheService()
+        {
+            var jsonString = string.Empty;
+            var submissionUrl = string.Empty;
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, 1);
+            backtraceSession.RequestHandler = new BacktraceHttpClientMock()
+            {
+                OnIvoke = (string url, BacktraceJObject json) =>
+                {
+                    jsonString = json.ToJson();
+                    submissionUrl = url;
+                }
+            };
+
+            backtraceSession.AddSessionEvent(SessionEventName);
+            backtraceSession.Send();
+
+            Assert.IsNotEmpty(jsonString);
+            Assert.AreEqual(submissionUrl, _submissionUrl);
+            Assert.IsEmpty(backtraceSession.SessionEvents);
+        }
+
+        [Test]
+        public void BacktraceSession_ShouldTriggerUploadProcessOnSendMethodWithOnlyUniqueEvent_DataWasSendToTheService()
+        {
+            var jsonString = string.Empty;
+            var submissionUrl = string.Empty;
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, 1);
+            backtraceSession.RequestHandler = new BacktraceHttpClientMock()
+            {
+                OnIvoke = (string url, BacktraceJObject json) =>
+                {
+                    jsonString = json.ToJson();
+                    submissionUrl = url;
+                }
+            };
+
+            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+            backtraceSession.Send();
+
+            Assert.IsNotEmpty(jsonString);
+            Assert.AreEqual(submissionUrl, _submissionUrl);
+            Assert.IsEmpty(backtraceSession.SessionEvents);
+        }
+
+
+        [Test]
+        public void BacktraceSession_ShouldntTriggerUploadWhenDataIsNotAvailable_DataWasntSendToBacktrace()
+        {
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, 1);
+            var requestHandler = new BacktraceHttpClientMock();
+            backtraceSession.RequestHandler = requestHandler;
+
+            backtraceSession.Send();
+
+            Assert.IsFalse(requestHandler.Called);
+        }
+
+        [Test]
+        public void BacktraceSession_ShouldTry3TimesOn503BeforeDroppingEvents_DataWasntSendToBacktrace()
+        {
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, 1);
+            var requestHandler = new BacktraceHttpClientMock()
+            {
+                StatusCode = 503
+            };
+            backtraceSession.RequestHandler = requestHandler;
+            backtraceSession.AddSessionEvent(SessionEventName);
+            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+            backtraceSession.Send();
+
+            Assert.AreEqual(requestHandler.NumberOfRequests, BacktraceSession.DefaultNumberOfRetries);
+        }
+
+        [Test]
+        public void BacktraceSession_ShouldTryAtLeastOneOnHttpFailure_DataWasntSendToBacktrace()
+        {
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, 1);
+            var requestHandler = new BacktraceHttpClientMock()
+            {
+                IsHttpError = true
+            };
+            backtraceSession.RequestHandler = requestHandler;
+            backtraceSession.AddSessionEvent(SessionEventName);
+            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+            backtraceSession.Send();
+
+            Assert.AreEqual(requestHandler.NumberOfRequests, 1);
+        }
+
+
+        [Test]
+        public void BacktraceSession_ShouldSkipMoreUniqueEventsWhenHitTheLimit_DataWasntSendToBacktrace()
+        {
+            const int maximumNumberOfEvents = 3;
+            const int numberOfTestEvents = 10;
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, maximumNumberOfEvents);
+
+            for (int i = 0; i < numberOfTestEvents; i++)
+            {
+                backtraceSession.AddUniqueEventAttribute($"{UniqueAttributeName} {i}", new Dictionary<string, string>() { { $"{UniqueAttributeName} {i}", "value" } });
+            }
+
+            Assert.AreEqual(maximumNumberOfEvents, backtraceSession.Count());
+        }
+
+        [Test]
+        public void BacktraceSession_ShouldSkipMoreSessionEventsWhenHitTheLimit_DataWasntSendToBacktrace()
+        {
+            const int maximumNumberOfEvents = 3;
+            const int numberOfTestEvents = 10;
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, maximumNumberOfEvents);
+
+            for (int i = 0; i < numberOfTestEvents; i++)
+            {
+                backtraceSession.AddSessionEvent($"{SessionEventName} {i}");
+            }
+
+            Assert.AreEqual(maximumNumberOfEvents, backtraceSession.Count());
+        }
+
+        [Test]
+        public void BacktraceSession_ShouldTriggerDownloadViaTickMethodWhenReachedMaximumNumberOfEvents_DataWasSendToBacktrace()
+        {
+            const int maximumNumberOfEvents = 3;
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, maximumNumberOfEvents);
+            var requestHandler = new BacktraceHttpClientMock();
+            backtraceSession.RequestHandler = requestHandler;
+            for (int i = 0; i < maximumNumberOfEvents; i++)
+            {
+                backtraceSession.AddSessionEvent($"{SessionEventName} {i}");
+            }
+
+            backtraceSession.Tick(0);
+
+            Assert.AreEqual(0, backtraceSession.Count());
+            Assert.AreEqual(1, requestHandler.NumberOfRequests);
+        }
+
+        [Test]
+        public void BacktraceSession_ShouldntTriggerDownloadViaTickMethodWhenDidntReachMaximumNumberOfEvents_DataWasSendToBacktrace()
+        {
+            const int maximumNumberOfEvents = 3;
+            const int expectedNumberOfEvents = 2;
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 1, maximumNumberOfEvents);
+            var requestHandler = new BacktraceHttpClientMock();
+            backtraceSession.RequestHandler = requestHandler;
+            for (int i = 0; i < expectedNumberOfEvents; i++)
+            {
+                backtraceSession.AddSessionEvent($"{SessionEventName} {i}");
+            }
+
+            backtraceSession.Tick(0);
+
+            Assert.AreEqual(expectedNumberOfEvents, backtraceSession.Count());
+            Assert.AreEqual(0, requestHandler.NumberOfRequests);
+        }
+
+
+        [Test]
+        public void BacktraceSession_ShouldTriggerDownloadAfterTimeIntervalHit_DataWasSendToBacktrace()
+        {
+            const int timeInterval = 10;
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, timeInterval, 3);
+            var requestHandler = new BacktraceHttpClientMock();
+            backtraceSession.RequestHandler = requestHandler;
+
+            backtraceSession.AddSessionEvent(SessionEventName);
+            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+
+            backtraceSession.Tick(timeInterval + 1);
+
+            Assert.AreEqual(0, backtraceSession.Count());
+            Assert.AreEqual(1, requestHandler.NumberOfRequests);
+        }
+
+        [Test]
+        public void BacktraceSession_ShouldntTriggerDownloadBeforeTimeIntervalHit_DataWasSendToBacktrace()
+        {
+            const int timeInterval = 10;
+            const int numberOfAddedEvents = 2;
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, timeInterval, 3);
+            var requestHandler = new BacktraceHttpClientMock();
+            backtraceSession.RequestHandler = requestHandler;
+
+            backtraceSession.AddSessionEvent(SessionEventName);
+            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+
+            backtraceSession.Tick(timeInterval - 1);
+
+            Assert.AreEqual(numberOfAddedEvents, backtraceSession.Count());
+            Assert.AreEqual(0, requestHandler.NumberOfRequests);
+        }
+
+
+        [Test]
+        public void BacktraceSession_ShouldTriggerDownloadAfterTimeIntervalHitAgain_DataWasSendToBacktrace()
+        {
+            const int timeInterval = 10;
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, timeInterval, 3);
+            var requestHandler = new BacktraceHttpClientMock();
+            backtraceSession.RequestHandler = requestHandler;
+
+            backtraceSession.AddSessionEvent(SessionEventName);
+            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+
+            backtraceSession.Tick(timeInterval + 1);
+
+            backtraceSession.AddSessionEvent(SessionEventName);
+            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+
+            backtraceSession.Tick((timeInterval * 2) + 1);
+
+            Assert.AreEqual(0, backtraceSession.Count());
+            Assert.AreEqual(2, requestHandler.NumberOfRequests);
+        }
+        [Test]
+        public void BacktraceSession_ShouldntTriggerDownloadAfterTimeIntervalFirstHit_DataWasSendToBacktrace()
+        {
+            const int timeInterval = 10;
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, timeInterval, 3);
+            var requestHandler = new BacktraceHttpClientMock();
+            backtraceSession.RequestHandler = requestHandler;
+
+            backtraceSession.AddSessionEvent(SessionEventName);
+            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+
+            backtraceSession.Tick(timeInterval + 1);
+
+            backtraceSession.AddSessionEvent(SessionEventName);
+            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+
+            backtraceSession.Tick(timeInterval + 2);
+
+            Assert.AreEqual(2, backtraceSession.Count());
+            Assert.AreEqual(1, requestHandler.NumberOfRequests);
+        }
+    }
+}

--- a/Tests/Runtime/Session/BacktraceSessionTests.cs
+++ b/Tests/Runtime/Session/BacktraceSessionTests.cs
@@ -254,5 +254,18 @@ namespace Backtrace.Unity.Tests.Runtime.Session
             Assert.AreEqual(2, backtraceSession.Count());
             Assert.AreEqual(1, requestHandler.NumberOfRequests);
         }
+
+        [Test]
+        public void BacktraceSessionDefaultEvent_ShouldSendDefaultEventOnTheApplicationStartup_DataWasSendToBacktrace()
+        {
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 10, 3);
+            var requestHandler = new BacktraceHttpClientMock();
+            backtraceSession.RequestHandler = requestHandler;
+
+            backtraceSession.SendStartupEvent();
+
+            Assert.AreEqual(1, requestHandler.NumberOfRequests);
+        }
+
     }
 }

--- a/Tests/Runtime/Session/BacktraceSessionTests.cs
+++ b/Tests/Runtime/Session/BacktraceSessionTests.cs
@@ -26,7 +26,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session
             var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, 1);
             backtraceSession.RequestHandler = new BacktraceHttpClientMock()
             {
-                OnIvoke = (string url, BacktraceJObject json) =>
+                OnInvoke = (string url, BacktraceJObject json) =>
                 {
                     jsonString = json.ToJson();
                     submissionUrl = url;
@@ -49,7 +49,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session
             var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, 1);
             backtraceSession.RequestHandler = new BacktraceHttpClientMock()
             {
-                OnIvoke = (string url, BacktraceJObject json) =>
+                OnInvoke = (string url, BacktraceJObject json) =>
                 {
                     jsonString = json.ToJson();
                     submissionUrl = url;
@@ -102,7 +102,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session
         }
 
         [Test]
-        public void BacktraceSession_ShouldTryAtLeastOneOnHttpFailure_DataWasntSendToBacktrace()
+        public void BacktraceSession_ShouldTryOnlyOnceOnHttpFailure_DataWasntSendToBacktrace()
         {
             var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, 1);
             var requestHandler = new BacktraceHttpClientMock()

--- a/Tests/Runtime/Session/BacktraceSessionTests.cs
+++ b/Tests/Runtime/Session/BacktraceSessionTests.cs
@@ -89,16 +89,16 @@ namespace Backtrace.Unity.Tests.Runtime.Session
             backtraceSession.AddSessionEvent(SessionEventName);
             backtraceSession.AddUniqueEvent(UniqueAttributeName);
             backtraceSession.Send();
-            for (int i = 0; i < BacktraceSession.DefaultNumberOfRetries; i++)
+            for (int i = 0; i < BacktraceSession.MaxNumberOfAttemps; i++)
             {
                 yield return new WaitForSeconds(1);
                 // immidiately run next update
-                var time = BacktraceSession.RetryTimeMax + (BacktraceSession.RetryTimeMax * i) + i + 1;
+                var time = BacktraceSession.MaxTimeBetweenRequests + (BacktraceSession.MaxTimeBetweenRequests * i) + i + 1;
                 backtraceSession.Tick(time);
             }
 
             yield return new WaitForSeconds(1);
-            Assert.AreEqual(BacktraceSession.DefaultNumberOfRetries, requestHandler.NumberOfRequests);
+            Assert.AreEqual(BacktraceSession.MaxNumberOfAttemps, requestHandler.NumberOfRequests);
         }
 
         [Test]

--- a/Tests/Runtime/Session/BacktraceSessionTests.cs
+++ b/Tests/Runtime/Session/BacktraceSessionTests.cs
@@ -93,7 +93,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session
             {
                 yield return new WaitForSeconds(1);
                 // immidiately run next update
-                var time = BacktraceSession.TimeoutTimeInSec + (BacktraceSession.TimeoutTimeInSec * i) + i + 1;
+                var time = BacktraceSession.RetryTimeMax + (BacktraceSession.RetryTimeMax * i) + i + 1;
                 backtraceSession.Tick(time);
             }
 

--- a/Tests/Runtime/Session/BacktraceSessionTests.cs
+++ b/Tests/Runtime/Session/BacktraceSessionTests.cs
@@ -53,7 +53,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session
                 }
             };
 
-            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+            backtraceSession.AddUniqueEvent(UniqueAttributeName);
             backtraceSession.Send();
 
             Assert.IsNotEmpty(jsonString);
@@ -84,7 +84,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session
             };
             backtraceSession.RequestHandler = requestHandler;
             backtraceSession.AddSessionEvent(SessionEventName);
-            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+            backtraceSession.AddUniqueEvent(UniqueAttributeName);
             backtraceSession.Send();
 
             Assert.AreEqual(requestHandler.NumberOfRequests, BacktraceSession.DefaultNumberOfRetries);
@@ -100,7 +100,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session
             };
             backtraceSession.RequestHandler = requestHandler;
             backtraceSession.AddSessionEvent(SessionEventName);
-            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+            backtraceSession.AddUniqueEvent(UniqueAttributeName);
             backtraceSession.Send();
 
             Assert.AreEqual(requestHandler.NumberOfRequests, 1);
@@ -116,7 +116,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session
 
             for (int i = 0; i < numberOfTestEvents; i++)
             {
-                backtraceSession.AddUniqueEventAttribute($"{UniqueAttributeName} {i}", new Dictionary<string, string>() { { $"{UniqueAttributeName} {i}", "value" } });
+                backtraceSession.AddUniqueEvent($"{UniqueAttributeName} {i}", new Dictionary<string, string>() { { $"{UniqueAttributeName} {i}", "value" } });
             }
 
             Assert.AreEqual(maximumNumberOfEvents, backtraceSession.Count());
@@ -185,7 +185,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session
             backtraceSession.RequestHandler = requestHandler;
 
             backtraceSession.AddSessionEvent(SessionEventName);
-            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+            backtraceSession.AddUniqueEvent(UniqueAttributeName);
 
             backtraceSession.Tick(timeInterval + 1);
 
@@ -203,7 +203,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session
             backtraceSession.RequestHandler = requestHandler;
 
             backtraceSession.AddSessionEvent(SessionEventName);
-            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+            backtraceSession.AddUniqueEvent(UniqueAttributeName);
 
             backtraceSession.Tick(timeInterval - 1);
 
@@ -221,12 +221,12 @@ namespace Backtrace.Unity.Tests.Runtime.Session
             backtraceSession.RequestHandler = requestHandler;
 
             backtraceSession.AddSessionEvent(SessionEventName);
-            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+            backtraceSession.AddUniqueEvent(UniqueAttributeName);
 
             backtraceSession.Tick(timeInterval + 1);
 
             backtraceSession.AddSessionEvent(SessionEventName);
-            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+            backtraceSession.AddUniqueEvent(UniqueAttributeName);
 
             backtraceSession.Tick((timeInterval * 2) + 1);
 
@@ -242,12 +242,12 @@ namespace Backtrace.Unity.Tests.Runtime.Session
             backtraceSession.RequestHandler = requestHandler;
 
             backtraceSession.AddSessionEvent(SessionEventName);
-            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+            backtraceSession.AddUniqueEvent(UniqueAttributeName);
 
             backtraceSession.Tick(timeInterval + 1);
 
             backtraceSession.AddSessionEvent(SessionEventName);
-            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+            backtraceSession.AddUniqueEvent(UniqueAttributeName);
 
             backtraceSession.Tick(timeInterval + 2);
 

--- a/Tests/Runtime/Session/BacktraceSessionTests.cs
+++ b/Tests/Runtime/Session/BacktraceSessionTests.cs
@@ -141,7 +141,8 @@ namespace Backtrace.Unity.Tests.Runtime.Session
         public void BacktraceSession_ShouldTriggerDownloadViaTickMethodWhenReachedMaximumNumberOfEvents_DataWasSendToBacktrace()
         {
             const int maximumNumberOfEvents = 3;
-            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, maximumNumberOfEvents);
+            const int defaultTimeIntervalInMs = 10;
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, defaultTimeIntervalInMs, maximumNumberOfEvents);
             var requestHandler = new BacktraceHttpClientMock();
             backtraceSession.RequestHandler = requestHandler;
             for (int i = 0; i < maximumNumberOfEvents; i++)
@@ -149,7 +150,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session
                 backtraceSession.AddSessionEvent($"{SessionEventName} {i}");
             }
 
-            backtraceSession.Tick(0);
+            backtraceSession.Tick(defaultTimeIntervalInMs + 1);
 
             Assert.AreEqual(0, backtraceSession.Count());
             Assert.AreEqual(1, requestHandler.NumberOfRequests);

--- a/Tests/Runtime/Session/BacktraceSessionTests.cs.meta
+++ b/Tests/Runtime/Session/BacktraceSessionTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 43fcae25de9b9474c83376257da3729b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/Session/Mocks/BacktraceHttpClientMock.cs
+++ b/Tests/Runtime/Session/Mocks/BacktraceHttpClientMock.cs
@@ -10,7 +10,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session.Mocks
     {
         public int NumberOfRequests { get; set; } = 0;
         public bool Called { get; set; } = false;
-        public Action<string, BacktraceJObject> OnIvoke { get; set; }
+        public Action<string, BacktraceJObject> OnInvoke { get; set; }
         public string Response { get; set; } = string.Empty;
         public long StatusCode { get; set; } = 200;
         public bool IsHttpError { get; set; } = false;
@@ -21,7 +21,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session.Mocks
         {
             NumberOfRequests++;
             Called = true;
-            OnIvoke?.Invoke(submissionUrl, jObject);
+            OnInvoke?.Invoke(submissionUrl, jObject);
             onComplete?.Invoke(StatusCode, IsHttpError, Response);
         }
 

--- a/Tests/Runtime/Session/SessionEventTests.cs
+++ b/Tests/Runtime/Session/SessionEventTests.cs
@@ -1,0 +1,71 @@
+﻿using Backtrace.Unity.Model.JsonData;
+using Backtrace.Unity.Services;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace Backtrace.Unity.Tests.Runtime.Session
+{
+    public class SessionEventTests
+    {
+        private readonly string _submissionUrl = "https://event-edge.backtrace.io/api/user-aggregation/events?token=TOKEN";
+        private AttributeProvider _attributeProvider = new AttributeProvider();
+        private const int DefaultMaximumNumberOfEventsInStore = 10;
+
+        [Test]
+        public void BacktraceSessionSessionEvents_ShouldAddCorrectlyUniqueEvent_StoreValidUniqueEvent()
+        {
+            const string sessionEventName = "scene-changed";
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
+
+            backtraceSession.AddSessionEvent(sessionEventName);
+
+            Assert.AreEqual(backtraceSession.SessionEvents.Count, 1);
+            var sessionEvent = backtraceSession.SessionEvents.First.Value;
+            Assert.AreEqual(sessionEvent.Name, sessionEventName);
+            Assert.AreNotEqual(sessionEvent.Timestamp, 0);
+        }
+
+
+        [Test]
+        public void BacktraceSessionSessionEvents_ShouldPreventFromAddingMultipleTheSameEvents_LastValueIsAvailable()
+        {
+            const string sessionEventName = "scene-changed";
+            const int numberOfTheSameEvents = 3;
+            string expectedLastKeyName = $"key-{numberOfTheSameEvents}";
+            string expectedLastKeyValue = numberOfTheSameEvents.ToString();
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
+
+            for (int i = 0; i <= numberOfTheSameEvents; i++)
+            {
+                backtraceSession.AddSessionEvent(sessionEventName, new Dictionary<string, string>() { { $"key-{i}", i.ToString() } });
+            }
+
+            Assert.AreEqual(backtraceSession.SessionEvents.Count, 1);
+            var sessionEvent = backtraceSession.SessionEvents.First.Value;
+            Assert.AreEqual(sessionEvent.Name, sessionEventName);
+            Assert.AreEqual(expectedLastKeyValue, sessionEvent.Attributes[expectedLastKeyName]);
+            Assert.AreEqual(1, sessionEvent.Attributes.Count);
+        }
+
+        [Test]
+        public void BacktraceSessionSessionEvents_ShouldntAddEmptyUniqueEvent_UniqueEventsAreEmpty()
+        {
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
+
+            backtraceSession.AddSessionEvent(string.Empty);
+
+            Assert.AreEqual(backtraceSession.UniqueEvents.Count, 0);
+        }
+
+
+        [Test]
+        public void BacktraceSessionSessionEvents_ShouldntAddNullableUniqueEvent_UniqueEventsAreEmpty()
+        {
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
+
+            backtraceSession.AddUniqueEventAttribute(null);
+
+            Assert.AreEqual(backtraceSession.UniqueEvents.Count, 0);
+        }
+    }
+}

--- a/Tests/Runtime/Session/SessionEventTests.cs
+++ b/Tests/Runtime/Session/SessionEventTests.cs
@@ -25,28 +25,6 @@ namespace Backtrace.Unity.Tests.Runtime.Session
             Assert.AreNotEqual(sessionEvent.Timestamp, 0);
         }
 
-
-        [Test]
-        public void BacktraceSessionSessionEvents_ShouldPreventFromAddingMultipleTheSameEvents_LastValueIsAvailable()
-        {
-            const string sessionEventName = "scene-changed";
-            const int numberOfTheSameEvents = 3;
-            string expectedLastKeyName = $"key-{numberOfTheSameEvents}";
-            string expectedLastKeyValue = numberOfTheSameEvents.ToString();
-            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
-
-            for (int i = 0; i <= numberOfTheSameEvents; i++)
-            {
-                backtraceSession.AddSessionEvent(sessionEventName, new Dictionary<string, string>() { { $"key-{i}", i.ToString() } });
-            }
-
-            Assert.AreEqual(backtraceSession.SessionEvents.Count, 1);
-            var sessionEvent = backtraceSession.SessionEvents.First.Value;
-            Assert.AreEqual(sessionEvent.Name, sessionEventName);
-            Assert.AreEqual(expectedLastKeyValue, sessionEvent.Attributes[expectedLastKeyName]);
-            Assert.AreEqual(1, sessionEvent.Attributes.Count);
-        }
-
         [Test]
         public void BacktraceSessionSessionEvents_ShouldntAddEmptyUniqueEvent_UniqueEventsAreEmpty()
         {
@@ -63,7 +41,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session
         {
             var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
 
-            backtraceSession.AddUniqueEventAttribute(null);
+            backtraceSession.AddUniqueEvent(null);
 
             Assert.AreEqual(backtraceSession.UniqueEvents.Count, 0);
         }

--- a/Tests/Runtime/Session/SessionEventTests.cs.meta
+++ b/Tests/Runtime/Session/SessionEventTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 09f527d1e32fd244ba7ae681525c1abd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/Session/UniqueEventsTests.cs
+++ b/Tests/Runtime/Session/UniqueEventsTests.cs
@@ -1,0 +1,129 @@
+﻿using Backtrace.Unity.Model.JsonData;
+using Backtrace.Unity.Services;
+using NUnit.Framework;
+using System.Collections.Generic;
+
+namespace Backtrace.Unity.Tests.Runtime.Session
+{
+    public class UniqueEventsTests
+    {
+        // existing attribute name in Backtrace
+        const string UniqueAttributeName = "scene.name";
+        private readonly string _submissionUrl = "https://event-edge.backtrace.io/api/user-aggregation/events?token=TOKEN";
+        private AttributeProvider _attributeProvider = new AttributeProvider();
+        private const int DefaultMaximumNumberOfEventsInStore = 10;
+
+        [Test]
+        public void BacktraceSessionUniqueEvents_ShouldAddCorrectlyUniqueEventWithEmptyAttributes_StoreValidUniqueEvent()
+        {
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
+
+            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName, null);
+
+            Assert.AreEqual(backtraceSession.UniqueEvents.Count, 1);
+            var uniqueEvent = backtraceSession.UniqueEvents.First.Value;
+            Assert.AreEqual(uniqueEvent.Name, UniqueAttributeName);
+            Assert.AreNotEqual(uniqueEvent.Timestamp, 0);
+            Assert.AreEqual(uniqueEvent.Attributes.Count, _attributeProvider.GenerateAttributes().Count);
+        }
+
+        [Test]
+        public void BacktraceSessionUniqueEvents_ShouldAddCorrectlyUniqueEventWithAttributes_StoreValidUniqueEvent()
+        {
+            const string expectedAttributeName = "foo";
+            const string expectedAttributeValue = "bar";
+            var attributes = new Dictionary<string, string>() { { expectedAttributeName, expectedAttributeValue } };
+            int expectedNumberOfAttributes = _attributeProvider.GenerateAttributes().Count + attributes.Count;
+
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
+
+            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName, attributes);
+
+            Assert.AreEqual(backtraceSession.UniqueEvents.Count, 1);
+            var uniqueEvent = backtraceSession.UniqueEvents.First.Value;
+            Assert.AreEqual(uniqueEvent.Name, UniqueAttributeName);
+            Assert.AreNotEqual(uniqueEvent.Timestamp, 0);
+            Assert.AreEqual(uniqueEvent.Attributes.Count, expectedNumberOfAttributes);
+        }
+
+        [Test]
+        public void BacktraceSessionUniqueEvents_ShouldAddCorrectlyUniqueEvent_StoreValidUniqueEvent()
+        {
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
+
+            var added = backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+
+            Assert.IsTrue(added);
+            Assert.AreEqual(backtraceSession.UniqueEvents.Count, 1);
+            var uniqueEvent = backtraceSession.UniqueEvents.First.Value;
+            Assert.AreEqual(uniqueEvent.Name, UniqueAttributeName);
+            Assert.AreNotEqual(uniqueEvent.Timestamp, 0);
+            Assert.AreEqual(uniqueEvent.Attributes.Count, _attributeProvider.GenerateAttributes().Count);
+        }
+
+        [Test]
+        public void BacktraceSessionUniqueEvents_ShouldPreventFromAddingEventIfThereIsNoAttribute_StoreValidUniqueEvent()
+        {
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
+
+            var added = backtraceSession.AddUniqueEventAttribute($"{UniqueAttributeName}-not-existing");
+
+            Assert.IsFalse(added);
+            Assert.AreEqual(backtraceSession.UniqueEvents.Count, 0);
+
+        }
+
+        [Test]
+        public void BacktraceSessionUniqueEvents_ShouldntAddEmptyUniqueEvent_UniqueEventsAreEmpty()
+        {
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
+
+            var added = backtraceSession.AddUniqueEventAttribute(string.Empty);
+
+            Assert.IsFalse(added);
+            Assert.AreEqual(backtraceSession.UniqueEvents.Count, 0);
+        }
+
+
+        [Test]
+        public void BacktraceSessionUniqueEvents_ShouldntAddNullableUniqueEvent_UniqueEventsAreEmpty()
+        {
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
+
+            backtraceSession.AddUniqueEventAttribute(null);
+
+            Assert.AreEqual(backtraceSession.UniqueEvents.Count, 0);
+        }
+
+        [Test]
+        public void BacktraceSessionUniqueEvents_UniqueEventAttributeValueDontChangeOverTime_UniqueEventAttributesStayTheSame()
+        {
+            const string initializationValue = "foo";
+            const string updatedValue = "bar";
+            _attributeProvider[UniqueAttributeName] = initializationValue;
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
+
+            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+            _attributeProvider[UniqueAttributeName] = updatedValue;
+
+            var uniqueEvent = backtraceSession.UniqueEvents.First.Value;
+            Assert.AreEqual(uniqueEvent.Attributes[UniqueAttributeName], initializationValue);
+        }
+
+
+        [Test]
+        public void BacktraceSessionUniqueEvents_UniqueEventAttributeExistsAfterDeletingItFromAttributeProvider_UniqueEventAttributesStayTheSame()
+        {
+
+            const string initializationValue = "foo";
+            _attributeProvider[UniqueAttributeName] = initializationValue;
+            var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
+
+            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+            _attributeProvider[UniqueAttributeName] = string.Empty;
+
+            var uniqueEvent = backtraceSession.UniqueEvents.First.Value;
+            Assert.AreEqual(uniqueEvent.Attributes[UniqueAttributeName], initializationValue);
+        }
+    }
+}

--- a/Tests/Runtime/Session/UniqueEventsTests.cs
+++ b/Tests/Runtime/Session/UniqueEventsTests.cs
@@ -18,7 +18,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session
         {
             var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
 
-            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName, null);
+            backtraceSession.AddUniqueEvent(UniqueAttributeName, null);
 
             Assert.AreEqual(backtraceSession.UniqueEvents.Count, 1);
             var uniqueEvent = backtraceSession.UniqueEvents.First.Value;
@@ -37,7 +37,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session
 
             var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
 
-            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName, attributes);
+            backtraceSession.AddUniqueEvent(UniqueAttributeName, attributes);
 
             Assert.AreEqual(backtraceSession.UniqueEvents.Count, 1);
             var uniqueEvent = backtraceSession.UniqueEvents.First.Value;
@@ -51,7 +51,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session
         {
             var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
 
-            var added = backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+            var added = backtraceSession.AddUniqueEvent(UniqueAttributeName);
 
             Assert.IsTrue(added);
             Assert.AreEqual(backtraceSession.UniqueEvents.Count, 1);
@@ -66,7 +66,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session
         {
             var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
 
-            var added = backtraceSession.AddUniqueEventAttribute($"{UniqueAttributeName}-not-existing");
+            var added = backtraceSession.AddUniqueEvent($"{UniqueAttributeName}-not-existing");
 
             Assert.IsFalse(added);
             Assert.AreEqual(backtraceSession.UniqueEvents.Count, 0);
@@ -78,7 +78,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session
         {
             var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
 
-            var added = backtraceSession.AddUniqueEventAttribute(string.Empty);
+            var added = backtraceSession.AddUniqueEvent(string.Empty);
 
             Assert.IsFalse(added);
             Assert.AreEqual(backtraceSession.UniqueEvents.Count, 0);
@@ -90,7 +90,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session
         {
             var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
 
-            backtraceSession.AddUniqueEventAttribute(null);
+            backtraceSession.AddUniqueEvent(null);
 
             Assert.AreEqual(backtraceSession.UniqueEvents.Count, 0);
         }
@@ -103,7 +103,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session
             _attributeProvider[UniqueAttributeName] = initializationValue;
             var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
 
-            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+            backtraceSession.AddUniqueEvent(UniqueAttributeName);
             _attributeProvider[UniqueAttributeName] = updatedValue;
 
             var uniqueEvent = backtraceSession.UniqueEvents.First.Value;
@@ -119,7 +119,7 @@ namespace Backtrace.Unity.Tests.Runtime.Session
             _attributeProvider[UniqueAttributeName] = initializationValue;
             var backtraceSession = new BacktraceSession(_attributeProvider, _submissionUrl, 0, DefaultMaximumNumberOfEventsInStore);
 
-            backtraceSession.AddUniqueEventAttribute(UniqueAttributeName);
+            backtraceSession.AddUniqueEvent(UniqueAttributeName);
             _attributeProvider[UniqueAttributeName] = string.Empty;
 
             var uniqueEvent = backtraceSession.UniqueEvents.First.Value;

--- a/Tests/Runtime/Session/UniqueEventsTests.cs.meta
+++ b/Tests/Runtime/Session/UniqueEventsTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cdaea5506432ef54eac0a0ab051711fd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This diff shows business logic responsible for event aggregation support in the Backtrace-Unity client. 

Information for reviewers:
* BacktraceClient - class responsible for Backtrace integration in Unity - creates a single instance of BacktraceSession on application startup. Developers can't create more instances than one. BacktraceClient manage BacktraceSession class lifecycle.
*  BacktraceSession allows adding unique (hearthbeat) events and session events.
* BacktraceSession tick method will be invoked by BacktraceClient every time when Unity Engine calls the update method. In Unity, we prefer to avoid timers and this solution prevents from reserving additional resources for timers, jobs etc.
* Diffs also contains integration tests and unit tests. If you have more idea about specific use cases for our users that we should also capture in this diff please let me know!

Code information for reviewers:
* Please focus on the business logic in the code review -  for example: `Why we remove session events after successful upload?`. 

This diff contains only code - no technical descriptions, release announcement, readme/changelog changes. We will handle those changes in different diff once when we will be ready to ship all updates that we want to add to 3.5.0 to our customers

