### PR TITLE
iOS structure size change

### DIFF
--- a/Runtime/Native/iOS/NativeClient.cs
+++ b/Runtime/Native/iOS/NativeClient.cs
@@ -129,9 +129,12 @@ namespace Backtrace.Unity.Runtime.Native.iOS
             }
             GetNativeAttributes(out IntPtr pUnmanagedArray, out int keysCount);
 
+            // calculate struct size for current OS.
+            // We multiply by 2 because Entry struct has two pointers
+            var structSize = IntPtr.Size * 2;
             for (int i = 0; i < keysCount; i++)
             {
-                var address = pUnmanagedArray + i * 16;
+                var address = pUnmanagedArray + i * structSize;
                 Entry entry = Marshal.PtrToStructure<Entry>(address);
                 result.Add(entry.Key, entry.Value);
             }


### PR DESCRIPTION
**Why**

Previously we assumed that structure size in the iOS is constant. Based on the feedback that we got from our customers we should be prepared for a situation when structure size is different. To achieve that we should start using IntPtr.Size - instead of assuming struct size has always the same size = 16.