### PR TITLE
Guess native library path when application context is not available

### DIFF
--- a/Runtime/Native/Android/NativeClient.cs
+++ b/Runtime/Native/Android/NativeClient.cs
@@ -148,26 +148,37 @@ namespace Backtrace.Unity.Runtime.Native.Android
                 // this case might happen for example in flutter.
                 if (activity == null)
                 {
-                    var sourceDirectory = Path.Combine(Path.GetDirectoryName(Application.dataPath), "lib");
-                    if (!Directory.Exists(sourceDirectory))
-                    {
-                        return string.Empty;
-                    }
-                    var libDirectory = Directory.GetDirectories(sourceDirectory);
-                    if (libDirectory.Length == 0)
-                    {
-                        return string.Empty;
-                    }
-                    else
-                    {
-                        return libDirectory[0];
-                    }
+                    return string.Empty;
                 }
                 using (var context = activity.Call<AndroidJavaObject>("getApplicationContext"))
                 using (var applicationInfo = context.Call<AndroidJavaObject>("getApplicationInfo"))
                 {
                     return applicationInfo.Get<string>("nativeLibraryDir");
                 }
+            }
+        }
+
+        /// <summary>
+        /// Guess native directory path based on the data path directory. 
+        /// GetNativeDirectoryPath method might return empty value when activity is not available
+        /// this might happen in flutter apps.
+        /// </summary>
+        /// <returns>Guessed path to lib directory</returns>
+        private string GuessNativeDirectoryPath()
+        {
+            var sourceDirectory = Path.Combine(Path.GetDirectoryName(Application.dataPath), "lib");
+            if (!Directory.Exists(sourceDirectory))
+            {
+                return string.Empty;
+            }
+            var libDirectory = Directory.GetDirectories(sourceDirectory);
+            if (libDirectory.Length == 0)
+            {
+                return string.Empty;
+            }
+            else
+            {
+                return libDirectory[0];
             }
         }
 
@@ -215,6 +226,10 @@ namespace Backtrace.Unity.Runtime.Native.Android
             }
 
             var libDirectory = GetNativeDirectoryPath();
+            if (string.IsNullOrEmpty(libDirectory) || !Directory.Exists(libDirectory))
+            {
+                libDirectory = GuessNativeDirectoryPath();
+            }
             if (!Directory.Exists(libDirectory))
             {
                 return;

--- a/Runtime/Native/Android/NativeClient.cs
+++ b/Runtime/Native/Android/NativeClient.cs
@@ -143,10 +143,31 @@ namespace Backtrace.Unity.Runtime.Native.Android
         {
             using (var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
             using (var activity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity"))
-            using (var context = activity.Call<AndroidJavaObject>("getApplicationContext"))
-            using (var applicationInfo = context.Call<AndroidJavaObject>("getApplicationInfo"))
             {
-                return applicationInfo.Get<string>("nativeLibraryDir");
+                // handle specific case when current activity is not available
+                // this case might happen for example in flutter.
+                if (activity == null)
+                {
+                    var sourceDirectory = Path.Combine(Path.GetDirectoryName(Application.dataPath), "lib");
+                    if (!Directory.Exists(sourceDirectory))
+                    {
+                        return string.Empty;
+                    }
+                    var libDirectory = Directory.GetDirectories(sourceDirectory);
+                    if (libDirectory.Length == 0)
+                    {
+                        return string.Empty;
+                    }
+                    else
+                    {
+                        return libDirectory[0];
+                    }
+                }
+                using (var context = activity.Call<AndroidJavaObject>("getApplicationContext"))
+                using (var applicationInfo = context.Call<AndroidJavaObject>("getApplicationInfo"))
+                {
+                    return applicationInfo.Get<string>("nativeLibraryDir");
+                }
             }
         }
 


### PR DESCRIPTION
**Why**

We detected that sometimes when the Unity Android solution is being generated by 3rd party plugin, the application context object might not be available on the application startup. In this situation, the plugin currently will throw an unhandled exception and won't initialize native integration. To prevent this situation we added an additional check for nullable application context and also added a code that still allows us to guess library path based on the most popular application setup.

