### PR TITLE
Escape control characters

### DIFF
--- a/Runtime/Json/BacktraceJObject.cs
+++ b/Runtime/Json/BacktraceJObject.cs
@@ -372,7 +372,7 @@ namespace Backtrace.Unity.Json
             return (char)((n - 10) + 97);
         }
 
-        public void ToCharAsUnicodeToStringBuilder(char c, StringBuilder output)
+        private void ToCharAsUnicodeToStringBuilder(char c, StringBuilder output)
         {
             output.AppendFormat("\\u{0}{1}{2}{3}",
                 IntToHex((c >> 12) & 15),

--- a/Runtime/Json/BacktraceJObject.cs
+++ b/Runtime/Json/BacktraceJObject.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
@@ -327,10 +328,10 @@ namespace Backtrace.Unity.Json
                 switch (c)
                 {
                     case '\\':
-                        output.AppendFormat("\\\\");
+                        output.Append("\\\\");
                         break;
                     case '"':
-                        output.AppendFormat("\\\"");
+                        output.Append("\\\"");
                         break;
                     case '\b':
                         output.Append("\\b");
@@ -348,10 +349,36 @@ namespace Backtrace.Unity.Json
                         output.Append("\\r");
                         break;
                     default:
-                        output.Append(c);
+                        if (char.GetUnicodeCategory(c) == UnicodeCategory.Control)
+                        {
+                            ToCharAsUnicodeToStringBuilder(c, output);
+                        }
+                        else
+                        {
+                            output.Append(c);
+                        }
                         break;
                 }
             }
+        }
+
+        private char IntToHex(int n)
+        {
+            if (n <= 9)
+            {
+                return (char)(n + 48);
+            }
+
+            return (char)((n - 10) + 97);
+        }
+
+        public void ToCharAsUnicodeToStringBuilder(char c, StringBuilder output)
+        {
+            output.AppendFormat("\\u{0}{1}{2}{3}",
+                IntToHex((c >> 12) & 15),
+                IntToHex((c >> 8) & 15),
+                IntToHex((c >> 4) & 15),
+                IntToHex(c & 15));
         }
     }
 }

--- a/Tests/Runtime/BacktraceJObjectTests.cs
+++ b/Tests/Runtime/BacktraceJObjectTests.cs
@@ -196,6 +196,22 @@ namespace Backtrace.Unity.Tests.Runtime
             yield return null;
         }
 
+        [Test]
+        public void TestDataSerialization_ShouldEscapeControlCharacters_JObjetGeneratedCorrectJson()
+        {
+            var testString = "✅🔮⛱😂^㊛ﺅɏ耀借俠⃐㫪";
+            var sampleObject = new SampleObject()
+            {
+                AgentName = testString
+            };
+
+            var jObject = new BacktraceJObject();
+            jObject.Add("AgentName", testString);
+            var json = jObject.ToJson();
+            var deserializedObject = JsonUtility.FromJson<SampleObject>(json);
+            Assert.AreEqual(sampleObject.AgentName, deserializedObject.AgentName);
+        }
+
         [UnityTest]
         public IEnumerator TestDataSerialization_ShouldEscapeInvalidStringValues_DataSerializeCorrectly()
         {


### PR DESCRIPTION
# Why

We detected a problem with the control characters that the Unity plugin sends. Without control characters escaping mechanism, invalid JSON provided by Unity plugin might break web ui parser. This diff correctly escapes control characters in the plugin.