### PR TITLE
Backtrace thread API improvements

### DIFF
--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -93,6 +93,22 @@ namespace Backtrace.Unity
             }
         }
 #endif
+        /// <summary>
+        /// Random object instance
+        /// </summary>
+        internal System.Random Random
+        {
+            get
+            {
+                if (_random == null)
+                {
+                    _random = new System.Random();
+                }
+                return _random;
+            }
+        }
+
+        private System.Random _random;
 
         internal Stack<BacktraceReport> BackgroundExceptions = new Stack<BacktraceReport>();
 
@@ -1086,7 +1102,8 @@ namespace Backtrace.Unity
             {
                 return false;
             }
-            return UnityEngine.Random.Range(0f, 1f) > Configuration.Sampling;
+            var value = Random.NextDouble();
+            return value > Configuration.Sampling;
 #endif
         }
 

--- a/Runtime/BacktraceDatabase.cs
+++ b/Runtime/BacktraceDatabase.cs
@@ -581,7 +581,7 @@ namespace Backtrace.Unity
             DatabasePath = Configuration.GetFullDatabasePath();
             if (string.IsNullOrEmpty(DatabasePath))
             {
-                Debug.LogWarning("Backtrace database path is empty or unvailable.");
+                Debug.LogWarning("Backtrace database path is empty or unavailable.");
                 return false;
             }
 

--- a/Runtime/BacktraceDatabase.cs
+++ b/Runtime/BacktraceDatabase.cs
@@ -581,7 +581,7 @@ namespace Backtrace.Unity
             DatabasePath = Configuration.GetFullDatabasePath();
             if (string.IsNullOrEmpty(DatabasePath))
             {
-                Debug.LogWarning("Backtrace database path is empty.");
+                Debug.LogWarning("Backtrace database path is empty or unvailable.");
                 return false;
             }
 

--- a/Runtime/Common/ClientPathHelper.cs
+++ b/Runtime/Common/ClientPathHelper.cs
@@ -59,7 +59,14 @@ namespace Backtrace.Unity.Common
             {
                 path = Path.Combine(Application.persistentDataPath, path);
             }
-            return Path.GetFullPath(path);
+            try
+            {
+                return Path.GetFullPath(path);
+            }
+            catch (Exception)
+            {
+                return string.Empty;
+            }
 
         }
     }

--- a/Runtime/Model/BacktraceReport.cs
+++ b/Runtime/Model/BacktraceReport.cs
@@ -205,7 +205,10 @@ namespace Backtrace.Unity.Model
                 {
                     // set attributes instead of fingerprint to still allow our user to define customer
                     // fingerprints for reports without stack trace and apply deduplication rules in report flow.
-                    Attributes[modFingerprintAttributeName] = Message.OnlyLetters().GetSha();
+                    var fingerPrint = string.IsNullOrEmpty(Message)
+                        ? "0000000000000000000000000000000000000000000000000000000000000000"
+                        : Message.OnlyLetters().GetSha();
+                    Attributes[modFingerprintAttributeName] = fingerPrint;
                 }
             }
 

--- a/Runtime/Model/Database/BacktraceDatabaseRecord.cs
+++ b/Runtime/Model/Database/BacktraceDatabaseRecord.cs
@@ -181,6 +181,10 @@ namespace Backtrace.Unity.Model.Database
         /// <returns>Saved database record</returns>
         internal static BacktraceDatabaseRecord ReadFromFile(FileInfo file)
         {
+            if (!file.Exists)
+            {
+                return null;
+            }
             using (StreamReader streamReader = file.OpenText())
             {
                 var json = streamReader.ReadToEnd();


### PR DESCRIPTION
# Why

This diff contains safe code that we should execute when a game executes Backtrace client code outside the main thread. This code also solves problems detected while I was trying to figure our correct solution to this issue.