### PR TITLE
Multiselect dropdown support

### DIFF
--- a/Editor/BacktraceConfigurationEditor.cs
+++ b/Editor/BacktraceConfigurationEditor.cs
@@ -221,7 +221,7 @@ namespace Backtrace.Unity.Editor
         /// if editor has to display multiselect dropdown by using enum flags. This code allows to generate
         /// multiselect dropdown based on the available enum.
         /// </summary>
-        /// <param name="propertyName">Enum proberty name</param>
+        /// <param name="propertyName">Enum property name</param>
         /// <param name="label">Label</param>
         /// <param name="serializedObject">Serialized object</param>
         private static void DrawMultiselectDropdown(string propertyName, string label, SerializedObject serializedObject)

--- a/Editor/BacktraceConfigurationEditor.cs
+++ b/Editor/BacktraceConfigurationEditor.cs
@@ -217,7 +217,7 @@ namespace Backtrace.Unity.Editor
         }
 
         /// <summary>
-        /// Draw multiselect dropdown. By default PropertyField won't work correctly in Untiy 2017/2018
+        /// Draw multiselect dropdown. By default PropertyField won't work correctly in Unity 2017/2018
         /// if editor has to display multiselect dropdown by using enum flags. This code allows to generate
         /// multiselect dropdown based on the available enum.
         /// </summary>


### PR DESCRIPTION
# Why

We discovered that the `EditorGUILayout.PropertyField` API that the Unity plugin uses to draw Backtrace configuration options on the UI doesn't work correctly on the old version of Unity with enum flags. By default, the user instead of selecting multiple values can select only one. 

This diff allows user to select multiple values in the backtrace-unity configuration window in the Unity 2017/2018