### PR TITLE
Prevent from changing source code collection while jobject iterate ov…

### DIFF
--- a/Runtime/Model/BacktraceLogManager.cs
+++ b/Runtime/Model/BacktraceLogManager.cs
@@ -102,9 +102,11 @@ namespace Backtrace.Unity.Model
         public string ToSourceCode()
         {
             var stringBuilder = new StringBuilder();
-            foreach (var item in LogQueue)
+
+            var logs = LogQueue.ToArray();
+            foreach (var log in logs)
             {
-                stringBuilder.AppendLine(item);
+                stringBuilder.AppendLine(log);
             }
             return stringBuilder.ToString();
         }


### PR DESCRIPTION
# Why

DOTS parallel job showed a problem with source code integration. When multiple jobs generate backtrace report, BacktraceJObject access LogQueue to generate unity engine logs, while other jobs might generate logs and modify enumerator used by BacktraceJobject.


