### PR TITLE
Bugfix/flag overflow

### DIFF
--- a/Editor/BacktraceConfigurationEditor.cs
+++ b/Editor/BacktraceConfigurationEditor.cs
@@ -236,7 +236,7 @@ namespace Backtrace.Unity.Editor
             var value = EditorGUILayout.EnumFlagsField(label, enumValue);
             if (EditorGUI.EndChangeCheck())
             {
-                property.intValue = Convert.ToInt32(value);
+                property.longValue = Convert.ToInt64(value);
             }
         }
     }


### PR DESCRIPTION
# Why

Backtrace-Unity minidump options allow to set up a flag that will cause an int overflow. This diff changes the value type in BacktraceConfiguration property to accept long instead of int. 