### PR TITLE
Unity 2018 and older ndk warning

### DIFF
--- a/Editor/BacktraceConfigurationEditor.cs
+++ b/Editor/BacktraceConfigurationEditor.cs
@@ -137,9 +137,16 @@ namespace Backtrace.Unity.Editor
 
 
 #if UNITY_ANDROID || UNITY_IOS || UNITY_STANDALONE_WIN
+                        SerializedProperty captureNativeCrashes = serializedObject.FindProperty("CaptureNativeCrashes");
                         EditorGUILayout.PropertyField(
-                            serializedObject.FindProperty("CaptureNativeCrashes"),
+                            captureNativeCrashes,
                             new GUIContent(BacktraceConfigurationLabels.CAPTURE_NATIVE_CRASHES));
+//#if !UNITY_2018_4_OR_NEWER
+                        if (captureNativeCrashes.boolValue)
+                        {
+                            EditorGUILayout.HelpBox("Native crsah reporter will be disabled for Untiy 2018 (and older) version that use NDK16b. Please contact Backtrace support to learn more about crash reporting tool.", MessageType.Warning);
+                        }
+//#endif
 
                         EditorGUILayout.PropertyField(
                             serializedObject.FindProperty("HandleANR"),


### PR DESCRIPTION
# Goal

This change allows displaying a warning message when a user uses Unity 2018 or an older version to develop an Android game. 

![image](https://user-images.githubusercontent.com/9386268/136044502-406cf07a-2f0c-4d88-aef6-7e79803b98a0.png)
![image](https://user-images.githubusercontent.com/9386268/136044563-b81c7938-5ea3-452c-aaff-b6a7d9fb0961.png)
