### PR TITLE
Warning message when filter report is set all All

### DIFF
--- a/Runtime/Extensions/EnumExtensions.cs
+++ b/Runtime/Extensions/EnumExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace Backtrace.Unity.Extensions
 {
-    internal static class EnumExtensions
+    public static class EnumExtensions
     {
 #if !(NET_STANDARD_2_0 && NET_4_6)
         internal static bool HasFlag(this Enum variable, Enum value)
@@ -29,5 +29,27 @@ namespace Backtrace.Unity.Extensions
             return false;
         }
 #endif
+
+        /// <summary>
+        /// Check if enum flag has all flags set
+        /// </summary>
+        /// <typeparam name="T">Type with enum flag</typeparam>
+        /// <param name="source">enum</param>
+        /// <returns>True if all options are set.</returns>
+        public static bool HasAllFlags<T>(this T source) where T : Enum
+        {
+            Type enumType = typeof(T);
+
+            var enumValues = Enum.GetValues(enumType);
+            foreach (var value in enumValues)
+            {
+                //long flag = (long)Convert.ChangeType(value, TypeCode.Int64);
+                if (!source.HasFlag((T)value))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
     }
 }


### PR DESCRIPTION
# Why

This change allows to print warning message when report filter is set to all so the backtrace-unity plugin will prevent from sending any report.
![image](https://user-images.githubusercontent.com/9386268/136077560-a9a55d9f-f48b-4b0d-a571-daa9b175c9b4.png)
