### PR TITLE
Enable editor sampling feature

### DIFF
--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -1093,18 +1093,12 @@ namespace Backtrace.Unity
         /// <returns>True, when client should skip report, otherwise false.</returns>
         private bool SamplingShouldSkip()
         {
-            // Sampling won't work in Editor mode - from editor we're allowing to send all type
-            // of possible errors.
-#if UNITY_EDITOR
-            return false;
-#else
             if (!Configuration || Configuration.Sampling == 1)
             {
                 return false;
             }
             var value = Random.NextDouble();
             return value > Configuration.Sampling;
-#endif
         }
 
         private void SendUnhandledException(BacktraceUnhandledException exception, bool invokeSkipApi = true)


### PR DESCRIPTION
# Why

Previously we didn't apply sampling settings in editor mode. This diff allows to filter reports in editor mode. 