### PR TITLE
Breadcrumbs initialization improvements

### DIFF
--- a/Runtime/BacktraceDatabase.cs
+++ b/Runtime/BacktraceDatabase.cs
@@ -36,7 +36,7 @@ namespace Backtrace.Unity
             {
                 if (_breadcrumbs == null)
                 {
-                    if (Enable && BacktraceBreadcrumbs.CanStoreBreadcrumbs(Configuration.LogLevel, Configuration.BacktraceBreadcrumbsLevel))
+                    if (Enable && Configuration.EnableBreadcrumbsSupport && BacktraceBreadcrumbs.CanStoreBreadcrumbs(Configuration.LogLevel, Configuration.BacktraceBreadcrumbsLevel))
                     {
                         _breadcrumbs = new BacktraceBreadcrumbs(new BacktraceStorageLogManager(Configuration.GetFullDatabasePath()));
                     }

--- a/Runtime/BacktraceDatabase.cs
+++ b/Runtime/BacktraceDatabase.cs
@@ -36,7 +36,7 @@ namespace Backtrace.Unity
             {
                 if (_breadcrumbs == null)
                 {
-                    if (Enable && Configuration.EnableBreadcrumbsSupport)
+                    if (Enable && BacktraceBreadcrumbs.CanStoreBreadcrumbs(Configuration.LogLevel, Configuration.BacktraceBreadcrumbsLevel))
                     {
                         _breadcrumbs = new BacktraceBreadcrumbs(new BacktraceStorageLogManager(Configuration.GetFullDatabasePath()));
                     }

--- a/Runtime/Model/BacktraceConfiguration.cs
+++ b/Runtime/Model/BacktraceConfiguration.cs
@@ -13,6 +13,21 @@ namespace Backtrace.Unity.Model
     [CreateAssetMenu(fileName = "Backtrace Configuration", menuName = "Backtrace/Configuration", order = 0)]
     public class BacktraceConfiguration : ScriptableObject
     {
+        private const BacktraceBreadcrumbType AllBreadcrumbsTypes =
+            BacktraceBreadcrumbType.Configuration |
+            BacktraceBreadcrumbType.Http |
+            BacktraceBreadcrumbType.Log |
+            BacktraceBreadcrumbType.Manual |
+            BacktraceBreadcrumbType.Navigation |
+            BacktraceBreadcrumbType.System |
+            BacktraceBreadcrumbType.User;
+
+        private const UnityEngineLogLevel AllLogTypes = UnityEngineLogLevel.Debug |
+            UnityEngineLogLevel.Error |
+            UnityEngineLogLevel.Fatal |
+            UnityEngineLogLevel.Info |
+            UnityEngineLogLevel.Warning;
+
         /// <summary>
         /// Backtrace server url
         /// </summary>
@@ -166,13 +181,13 @@ namespace Backtrace.Unity.Model
         /// Backtrace breadcrumbs log level controls what type of information will be available in the breadcrumbs file
         /// </summary>
         [Tooltip("Breadcrumbs support breadcrumbs level- Backtrace breadcrumbs log level controls what type of information will be available in the breadcrumb file")]
-        public BacktraceBreadcrumbType BacktraceBreadcrumbsLevel;
+        public BacktraceBreadcrumbType BacktraceBreadcrumbsLevel = AllBreadcrumbsTypes;
 
         /// <summary>
         /// Backtrace Unity Engine log Level controls what log types will be included in the final breadcrumbs file
         /// </summary>
         [Tooltip("Breadcrumbs log level")]
-        public UnityEngineLogLevel LogLevel;
+        public UnityEngineLogLevel LogLevel = AllLogTypes;
 
         /// <summary>
         /// Use normalized exception message instead environment stack trace, when exception doesn't have stack trace

--- a/Runtime/Model/BacktraceHttpClient.cs
+++ b/Runtime/Model/BacktraceHttpClient.cs
@@ -167,7 +167,7 @@ namespace Backtrace.Unity.Model
 
             foreach (var file in uniqueAttachments)
             {
-                if (string.IsNullOrEmpty(file) || File.Exists(file) == false)
+                if (string.IsNullOrEmpty(file) || !File.Exists(file))
                 {
                     continue;
                 }

--- a/Runtime/Model/BacktraceHttpClient.cs
+++ b/Runtime/Model/BacktraceHttpClient.cs
@@ -158,8 +158,8 @@ namespace Backtrace.Unity.Model
             {
                 return;
             }
-            // make sure attachments are not bigger than 10 Mb.
-            const int maximumAttachmentSize = 10000000;
+            // make sure attachments are not bigger than 10 MiB.
+            const int maximumAttachmentSize = 10 * 1024 * 1024;
             const string attachmentPrefix = "attachment_";
 
             var uniqueAttachments = new HashSet<string>(attachments.Reverse());

--- a/Runtime/Model/BacktraceHttpClient.cs
+++ b/Runtime/Model/BacktraceHttpClient.cs
@@ -167,7 +167,14 @@ namespace Backtrace.Unity.Model
 
             foreach (var file in uniqueAttachments)
             {
-                if (string.IsNullOrEmpty(file) || File.Exists(file) == false || new FileInfo(file).Length > maximumAttachmentSize)
+                if (string.IsNullOrEmpty(file) || File.Exists(file) == false)
+                {
+                    continue;
+                }
+
+                var fileSize = new FileInfo(file).Length;
+                var isInvalidFileSize = fileSize > maximumAttachmentSize || fileSize == 0;
+                if (isInvalidFileSize)
                 {
                     continue;
                 }

--- a/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbType.cs
+++ b/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbType.cs
@@ -8,6 +8,7 @@ namespace Backtrace.Unity.Model.Breadcrumbs
     [Flags]
     public enum BacktraceBreadcrumbType
     {
+        None = 0,
         Manual = BreadcrumbLevel.Manual,
         Log = BreadcrumbLevel.Log,
         Navigation = BreadcrumbLevel.Navigation,

--- a/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbs.cs
+++ b/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbs.cs
@@ -185,7 +185,7 @@ namespace Backtrace.Unity.Model.Breadcrumbs
 
         public static bool CanStoreBreadcrumbs(UnityEngineLogLevel logLevel, BacktraceBreadcrumbType backtraceBreadcrumbsLevel)
         {
-            return (ulong)backtraceBreadcrumbsLevel != 0 && (ulong)logLevel != 0;
+            return backtraceBreadcrumbsLevel != BacktraceBreadcrumbType.None && logLevel != UnityEngineLogLevel.None;
         }
     }
 }

--- a/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbs.cs
+++ b/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbs.cs
@@ -182,5 +182,10 @@ namespace Backtrace.Unity.Model.Breadcrumbs
         {
             EventHandler.Update();
         }
+
+        public static bool CanStoreBreadcrumbs(UnityEngineLogLevel logLevel, BacktraceBreadcrumbType backtraceBreadcrumbsLevel)
+        {
+            return (ulong)backtraceBreadcrumbsLevel != 0 && (ulong)logLevel != 0;
+        }
     }
 }

--- a/Runtime/Model/Breadcrumbs/UnityEngineLogLevel.cs
+++ b/Runtime/Model/Breadcrumbs/UnityEngineLogLevel.cs
@@ -8,6 +8,7 @@ namespace Backtrace.Unity.Model.Breadcrumbs
     [Flags]
     public enum UnityEngineLogLevel
     {
+        None = 0,
         Debug = 1,
         Warning = 2,
         Info = 4,

--- a/Runtime/Model/Database/BacktraceDatabaseRecord.cs
+++ b/Runtime/Model/Database/BacktraceDatabaseRecord.cs
@@ -95,7 +95,8 @@ namespace Backtrace.Unity.Model.Database
                 return null;
             }
 
-            return File.ReadAllText(DiagnosticDataPath);
+            DiagnosticDataJson = File.ReadAllText(DiagnosticDataPath);
+            return DiagnosticDataJson;
         }
 
         /// <summary>

--- a/Tests/Runtime/Breadcrumbs/BacktraceBreadcrumbsTypeTests.cs
+++ b/Tests/Runtime/Breadcrumbs/BacktraceBreadcrumbsTypeTests.cs
@@ -30,6 +30,31 @@ namespace Backtrace.Unity.Tests.Runtime.Breadcrumbs
         }
 
         [Test]
+        public void TestBreadcrumbsInitializationForInvalidLogLevel_ShouldReturnFalse_BreadcrumbsConfigurationIsInvalid()
+        {
+            // level not set - test simulates Unity Editor behavior 
+            UnityEngineLogLevel level = 0;
+            // any defined type
+            BacktraceBreadcrumbType backtraceBreadcrumbType = BacktraceBreadcrumbType.Log;
+
+            var result = BacktraceBreadcrumbs.CanStoreBreadcrumbs(level, backtraceBreadcrumbType);
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void TestBreadcrumbsInitializationForValidOptions_ShouldReturnTrue_BreadcrumbsConfigurationIsValid()
+        {
+            // any log level that might be selected by user
+            UnityEngineLogLevel level = UnityEngineLogLevel.Debug;
+            BacktraceBreadcrumbType backtraceBreadcrumbType = BacktraceBreadcrumbType.Log;
+
+            var result = BacktraceBreadcrumbs.CanStoreBreadcrumbs(level, backtraceBreadcrumbType);
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
         public void TestSystemLogs_ShouldEnableThem_EventsAreSet()
         {
             var inMemoryBreadcrumbStorage = new BacktraceInMemoryLogManager();

--- a/Tests/Runtime/Breadcrumbs/BacktraceBreadcrumbsTypeTests.cs
+++ b/Tests/Runtime/Breadcrumbs/BacktraceBreadcrumbsTypeTests.cs
@@ -33,7 +33,7 @@ namespace Backtrace.Unity.Tests.Runtime.Breadcrumbs
         public void TestBreadcrumbsInitializationForInvalidLogLevel_ShouldReturnFalse_BreadcrumbsConfigurationIsInvalid()
         {
             // level not set - test simulates Unity Editor behavior 
-            UnityEngineLogLevel level = 0;
+            UnityEngineLogLevel level = UnityEngineLogLevel.None;
             // any defined type
             BacktraceBreadcrumbType backtraceBreadcrumbType = BacktraceBreadcrumbType.Log;
 

--- a/Tests/Runtime/Breadcrumbs/BreadcrumbsLogLevelTests.cs
+++ b/Tests/Runtime/Breadcrumbs/BreadcrumbsLogLevelTests.cs
@@ -96,9 +96,9 @@ namespace Backtrace.Unity.Tests.Runtime.Breadcrumbs
         public void TestBreadcrumbsInitializationForInvalidBreadcrumbType_ShouldReturnFalse_BreadcrumbsConfigurationIsInvalid()
         {
             // type not set - test simulates Unity Editor behavior 
-            BacktraceBreadcrumbType backtraceBreadcrumbType = BacktraceBreadcrumbType.Log;
+            BacktraceBreadcrumbType backtraceBreadcrumbType = BacktraceBreadcrumbType.None;
             // any defined type
-            UnityEngineLogLevel level = 0;
+            UnityEngineLogLevel level = UnityEngineLogLevel.Fatal;
 
             var result = BacktraceBreadcrumbs.CanStoreBreadcrumbs(level, backtraceBreadcrumbType);
 

--- a/Tests/Runtime/Breadcrumbs/BreadcrumbsLogLevelTests.cs
+++ b/Tests/Runtime/Breadcrumbs/BreadcrumbsLogLevelTests.cs
@@ -93,6 +93,19 @@ namespace Backtrace.Unity.Tests.Runtime.Breadcrumbs
         }
 
         [Test]
+        public void TestBreadcrumbsInitializationForInvalidBreadcrumbType_ShouldReturnFalse_BreadcrumbsConfigurationIsInvalid()
+        {
+            // type not set - test simulates Unity Editor behavior 
+            BacktraceBreadcrumbType backtraceBreadcrumbType = BacktraceBreadcrumbType.Log;
+            // any defined type
+            UnityEngineLogLevel level = 0;
+
+            var result = BacktraceBreadcrumbs.CanStoreBreadcrumbs(level, backtraceBreadcrumbType);
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
         public void DebugLogLevel_ShouldFilterDebugLogLevel_BreadcrumbsWasntSave()
         {
             const string message = "message";


### PR DESCRIPTION
# Why

This diff contains small breadcrumbs initialization improvements. With these improvements, backtrace-unity will:
* disable breadcrumbs integration, when a client decides to not select any supported log level or any breadcrumb type,
* ignores files that are empty.