### PR TITLE
Decrease default texture quality

### DIFF
--- a/Runtime/Model/Database/BacktraceDatabaseAttachmentManager.cs
+++ b/Runtime/Model/Database/BacktraceDatabaseAttachmentManager.cs
@@ -109,10 +109,8 @@ namespace Backtrace.Unity.Model.Database
                     RenderTexture screenTexture = RenderTexture.GetTemporary(Screen.width, Screen.height);
                     ScreenCapture.CaptureScreenshotIntoRenderTexture(screenTexture);
 #else
-                    
-Texture2D screenTexture = ScreenCapture.CaptureScreenshotAsTexture();
+                    Texture2D screenTexture = ScreenCapture.CaptureScreenshotAsTexture();
 #endif
-
                     // Create a render texture to render into
                     RenderTexture rt = RenderTexture.GetTemporary(targetWidth, targetHeight);
 
@@ -141,9 +139,8 @@ Texture2D screenTexture = ScreenCapture.CaptureScreenshotAsTexture();
 #if UNITY_2019_1_OR_NEWER
                     RenderTexture.ReleaseTemporary(screenTexture);
 #else
-                        GameObject.Destroy(screenTexture);
+                    GameObject.Destroy(screenTexture);
 #endif
-
                     File.WriteAllBytes(screenshotPath, result.EncodeToJPG(ScreenshotQuality));
                     GameObject.Destroy(result);
 

--- a/Runtime/Model/Database/BacktraceDatabaseAttachmentManager.cs
+++ b/Runtime/Model/Database/BacktraceDatabaseAttachmentManager.cs
@@ -23,7 +23,7 @@ namespace Backtrace.Unity.Model.Database
         {
             _settings = settings;
             ScreenshotMaxHeight = Screen.height;
-            ScreenshotQuality = 90;
+            ScreenshotQuality = 25;
         }
 
         public IEnumerable<string> GetReportAttachments(BacktraceData data)


### PR DESCRIPTION
# Why

This diff decreases the default screenshot quality generated by backtrace-unity when a user checks options to include screenshots in each backtrace-report.