### PR TITLE
Breadcrumbs ANR support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Backtrace Unity Release Notes
 
+## Version 3.7.0-preview.3
+
+- When an ANR/Hang is detected, it is now added to the Breadcrumbs on all the platforms we support ANRs for
+
 ## Version 3.7.0-preview.2
 
 - Sampling has been enabled in the editor mode.

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -536,7 +536,7 @@ namespace Backtrace.Unity
                 Database = GetComponent<BacktraceDatabase>();
                 if (Database != null)
                 {
-                    _breadcrumbs = Database.Breadcrumbs as BacktraceBreadcrumbs;
+                    _breadcrumbs = (BacktraceBreadcrumbs)Database.Breadcrumbs;
                     Database.Reload();
                     Database.SetApi(BacktraceApi);
                     Database.SetReportWatcher(_reportLimitWatcher);

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -25,8 +25,13 @@ namespace Backtrace.Unity
     public class BacktraceClient : MonoBehaviour, IBacktraceClient
     {
         public const string VERSION = "3.7.0-preview.2";
-
+        internal const string DefaultBacktraceGameObjectName = "BacktraceClient";
         public BacktraceConfiguration Configuration;
+
+        /// <summary>
+        /// Breadcrumbs instance for internal use. This instance allows to make system calls
+        /// </summary>
+        private BacktraceBreadcrumbs _breadcrumbs;
 
         /// <summary>
         /// Backtrace Breadcrumbs
@@ -35,11 +40,7 @@ namespace Backtrace.Unity
         {
             get
             {
-                if (Database == null)
-                {
-                    return null;
-                }
-                return Database.Breadcrumbs;
+                return _breadcrumbs;
             }
         }
 
@@ -383,7 +384,7 @@ namespace Backtrace.Unity
         /// param name="attachments">List of attachments </param>
         /// <param name="gameObjectName">game object name</param>
         /// <returns>Backtrace client</returns>
-        public static BacktraceClient Initialize(BacktraceConfiguration configuration, Dictionary<string, string> attributes = null, string gameObjectName = "BacktraceClient")
+        public static BacktraceClient Initialize(BacktraceConfiguration configuration, Dictionary<string, string> attributes = null, string gameObjectName = DefaultBacktraceGameObjectName)
         {
             if (string.IsNullOrEmpty(gameObjectName))
             {
@@ -422,7 +423,7 @@ namespace Backtrace.Unity
         /// <param name="attributes">Client side attributes</param>
         /// <param name="gameObjectName">game object name</param>
         /// <returns>Backtrace client</returns>
-        public static BacktraceClient Initialize(string url, string databasePath, Dictionary<string, string> attributes = null, string gameObjectName = "BacktraceClient")
+        public static BacktraceClient Initialize(string url, string databasePath, Dictionary<string, string> attributes = null, string gameObjectName = DefaultBacktraceGameObjectName)
         {
             return Initialize(url, databasePath, attributes, null, gameObjectName);
         }
@@ -436,7 +437,7 @@ namespace Backtrace.Unity
         /// <param name="attachments">Paths to attachments that Backtrace client will include in managed/native reports</param>
         /// <param name="gameObjectName">game object name</param>
         /// <returns>Backtrace client</returns>
-        public static BacktraceClient Initialize(string url, string databasePath, Dictionary<string, string> attributes = null, string[] attachments = null, string gameObjectName = "BacktraceClient")
+        public static BacktraceClient Initialize(string url, string databasePath, Dictionary<string, string> attributes = null, string[] attachments = null, string gameObjectName = DefaultBacktraceGameObjectName)
         {
             var configuration = ScriptableObject.CreateInstance<BacktraceConfiguration>();
             configuration.ServerUrl = url;
@@ -454,7 +455,7 @@ namespace Backtrace.Unity
         /// <param name="attributes">Client side attributes</param>
         /// <param name="gameObjectName">game object name</param>
         /// <returns>Backtrace client</returns>
-        public static BacktraceClient Initialize(string url, Dictionary<string, string> attributes = null, string gameObjectName = "BacktraceClient")
+        public static BacktraceClient Initialize(string url, Dictionary<string, string> attributes = null, string gameObjectName = DefaultBacktraceGameObjectName)
         {
             return Initialize(url, attributes, new string[0], gameObjectName);
         }
@@ -467,7 +468,7 @@ namespace Backtrace.Unity
         /// <param name="attachments">Paths to attachments that Backtrace client will include in managed/native reports</param>
         /// <param name="gameObjectName">game object name</param>
         /// <returns>Backtrace client</returns>
-        public static BacktraceClient Initialize(string url, Dictionary<string, string> attributes = null, string[] attachments = null, string gameObjectName = "BacktraceClient")
+        public static BacktraceClient Initialize(string url, Dictionary<string, string> attributes = null, string[] attachments = null, string gameObjectName = DefaultBacktraceGameObjectName)
         {
             var configuration = ScriptableObject.CreateInstance<BacktraceConfiguration>();
             configuration.ServerUrl = url;
@@ -535,12 +536,13 @@ namespace Backtrace.Unity
                 Database = GetComponent<BacktraceDatabase>();
                 if (Database != null)
                 {
+                    _breadcrumbs = Database.Breadcrumbs as BacktraceBreadcrumbs;
                     Database.Reload();
                     Database.SetApi(BacktraceApi);
                     Database.SetReportWatcher(_reportLimitWatcher);
-                    if (Database.Breadcrumbs != null)
+                    if (_breadcrumbs != null)
                     {
-                        breadcrumbsPath = Database.Breadcrumbs.GetBreadcrumbLogPath();
+                        breadcrumbsPath = _breadcrumbs.GetBreadcrumbLogPath();
 
                     }
                 }
@@ -566,7 +568,7 @@ namespace Backtrace.Unity
                 {
                     nativeAttachments.Add(breadcrumbsPath);
                 }
-                _nativeClient = NativeClientFactory.CreateNativeClient(Configuration, name, scopedAttributes, nativeAttachments);
+                _nativeClient = NativeClientFactory.CreateNativeClient(Configuration, name, _breadcrumbs, scopedAttributes, nativeAttachments);
                 AttributeProvider.AddDynamicAttributeProvider(_nativeClient);
                 Database.EnableBreadcrumbsSupport();
             }
@@ -652,9 +654,9 @@ namespace Backtrace.Unity
 
         private void Awake()
         {
-            if (Breadcrumbs != null)
+            if (_breadcrumbs != null)
             {
-                Breadcrumbs.FromMonoBehavior("Application awake", LogType.Assert, null);
+                _breadcrumbs.FromMonoBehavior("Application awake", LogType.Assert, null);
             }
             Refresh();
         }
@@ -666,7 +668,7 @@ namespace Backtrace.Unity
         {
             if (_nativeClient != null)
             {
-                _nativeClient.UpdateClientTime(Time.unscaledTime);
+                _nativeClient.Update(Time.unscaledTime);
             }
 
 #if !UNITY_WEBGL
@@ -692,10 +694,10 @@ namespace Backtrace.Unity
         private void OnDestroy()
         {
             Enabled = false;
-            if (Breadcrumbs != null)
+            if (_breadcrumbs != null)
             {
-                Breadcrumbs.FromMonoBehavior("Backtrace Client: OnDestroy", LogType.Warning, null);
-                Breadcrumbs.UnregisterEvents();
+                _breadcrumbs.FromMonoBehavior("Backtrace Client: OnDestroy", LogType.Warning, null);
+                _breadcrumbs.UnregisterEvents();
             }
             _instance = null;
             Application.logMessageReceived -= HandleUnityMessage;
@@ -739,9 +741,9 @@ namespace Backtrace.Unity
               message: message,
               attachmentPaths: attachmentPaths,
               attributes: attributes);
-            if (Breadcrumbs != null)
+            if (_breadcrumbs != null)
             {
-                Breadcrumbs.FromBacktrace(report);
+                _breadcrumbs.FromBacktrace(report);
             }
             _backtraceLogManager.Enqueue(report);
             SendReport(report);
@@ -761,9 +763,9 @@ namespace Backtrace.Unity
             }
 
             var report = new BacktraceReport(exception, attributes, attachmentPaths);
-            if (Breadcrumbs != null)
+            if (_breadcrumbs != null)
             {
-                Breadcrumbs.FromBacktrace(report);
+                _breadcrumbs.FromBacktrace(report);
             }
             _backtraceLogManager.Enqueue(report);
             SendReport(report);
@@ -780,9 +782,9 @@ namespace Backtrace.Unity
             {
                 return;
             }
-            if (Breadcrumbs != null)
+            if (_breadcrumbs != null)
             {
-                Breadcrumbs.FromBacktrace(report);
+                _breadcrumbs.FromBacktrace(report);
             }
             _backtraceLogManager.Enqueue(report);
             SendReport(report, sendCallback);
@@ -1013,9 +1015,9 @@ namespace Backtrace.Unity
 
         internal void OnApplicationPause(bool pause)
         {
-            if (Breadcrumbs != null)
+            if (_breadcrumbs != null)
             {
-                Breadcrumbs.FromMonoBehavior("Application pause", LogType.Assert, new Dictionary<string, string> { { "paused", pause.ToString(CultureInfo.InvariantCulture).ToLower() } });
+                _breadcrumbs.FromMonoBehavior("Application pause", LogType.Assert, new Dictionary<string, string> { { "paused", pause.ToString(CultureInfo.InvariantCulture).ToLower() } });
             }
             if (_nativeClient != null)
             {

--- a/Runtime/BacktraceDatabase.cs
+++ b/Runtime/BacktraceDatabase.cs
@@ -25,7 +25,7 @@ namespace Backtrace.Unity
 
         public BacktraceConfiguration Configuration;
 
-        internal BacktraceBreadcrumbs _breadcrumbs;
+        private BacktraceBreadcrumbs _breadcrumbs;
 
         /// <summary>
         /// Backtrace Breadcrumbs

--- a/Runtime/BacktraceDatabase.cs
+++ b/Runtime/BacktraceDatabase.cs
@@ -25,7 +25,7 @@ namespace Backtrace.Unity
 
         public BacktraceConfiguration Configuration;
 
-        private BacktraceBreadcrumbs _breadcrumbs;
+        internal BacktraceBreadcrumbs _breadcrumbs;
 
         /// <summary>
         /// Backtrace Breadcrumbs
@@ -38,7 +38,10 @@ namespace Backtrace.Unity
                 {
                     if (Enable && Configuration.EnableBreadcrumbsSupport && BacktraceBreadcrumbs.CanStoreBreadcrumbs(Configuration.LogLevel, Configuration.BacktraceBreadcrumbsLevel))
                     {
-                        _breadcrumbs = new BacktraceBreadcrumbs(new BacktraceStorageLogManager(Configuration.GetFullDatabasePath()));
+                        _breadcrumbs = new BacktraceBreadcrumbs(
+                            new BacktraceStorageLogManager(Configuration.GetFullDatabasePath()),
+                            Configuration.BacktraceBreadcrumbsLevel,
+                            Configuration.LogLevel);
                     }
                 }
                 return _breadcrumbs;
@@ -729,7 +732,7 @@ namespace Backtrace.Unity
             {
                 return false;
             }
-            return _breadcrumbs.EnableBreadcrumbs(Configuration.BacktraceBreadcrumbsLevel, Configuration.LogLevel);
+            return _breadcrumbs.EnableBreadcrumbs();
         }
     }
 }

--- a/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbs.cs
+++ b/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbs.cs
@@ -29,8 +29,10 @@ namespace Backtrace.Unity.Model.Breadcrumbs
         /// Determine if breadcrumbs are enabled
         /// </summary>
         private bool _enabled = false;
-        public BacktraceBreadcrumbs(IBacktraceLogManager logManager)
+        public BacktraceBreadcrumbs(IBacktraceLogManager logManager, BacktraceBreadcrumbType level, UnityEngineLogLevel unityLogLevel)
         {
+            BreadcrumbsLevel = level;
+            UnityLogLevel = unityLogLevel;
             LogManager = logManager;
             EventHandler = new BacktraceBreadcrumbsEventHandler(this);
         }
@@ -43,22 +45,24 @@ namespace Backtrace.Unity.Model.Breadcrumbs
         {
             return LogManager.Clear();
         }
-
         public bool EnableBreadcrumbs(BacktraceBreadcrumbType level, UnityEngineLogLevel unityLogLevel)
+        {
+            UnityLogLevel = unityLogLevel;
+            BreadcrumbsLevel = level;
+            return EnableBreadcrumbs();
+        }
+        public bool EnableBreadcrumbs()
         {
             if (_enabled)
             {
                 return false;
             }
-            BreadcrumbsLevel = level;
-            UnityLogLevel = unityLogLevel;
-
             var breadcrumbStorageEnabled = LogManager.Enable();
             if (!breadcrumbStorageEnabled)
             {
                 return false;
             }
-            EventHandler.Register(level);
+            EventHandler.Register(BreadcrumbsLevel);
             return true;
         }
 
@@ -156,7 +160,7 @@ namespace Backtrace.Unity.Model.Breadcrumbs
             return UnityLogLevel.HasFlag(type);
         }
 
-        internal UnityEngineLogLevel ConvertLogTypeToLogLevel(LogType type)
+        internal static UnityEngineLogLevel ConvertLogTypeToLogLevel(LogType type)
         {
             switch (type)
             {

--- a/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbsEventHandler.cs
+++ b/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbsEventHandler.cs
@@ -138,7 +138,7 @@ namespace Backtrace.Unity.Model.Breadcrumbs
 
         private void Log(string message, LogType level, BreadcrumbLevel breadcrumbLevel, IDictionary<string, string> attributes = null)
         {
-            var type = _breadcrumbs.ConvertLogTypeToLogLevel(level);
+            var type = BacktraceBreadcrumbs.ConvertLogTypeToLogLevel(level);
             if (!_breadcrumbs.ShouldLog(type))
             {
                 return;

--- a/Runtime/Model/Breadcrumbs/IBacktraceBreadcrumbs.cs
+++ b/Runtime/Model/Breadcrumbs/IBacktraceBreadcrumbs.cs
@@ -7,6 +7,8 @@ namespace Backtrace.Unity.Model.Breadcrumbs
     public interface IBacktraceBreadcrumbs
     {
         BacktraceBreadcrumbType BreadcrumbsLevel { get; }
+        bool EnableBreadcrumbs();
+        [Obsolete("Please use EnableBreadcurmbs instead. This function will be removed in the future updates")]
         bool EnableBreadcrumbs(BacktraceBreadcrumbType level, UnityEngineLogLevel unityLogLevel);
         bool ClearBreadcrumbs();
         bool Log(string message, LogType type, IDictionary<string, string> attributes);

--- a/Runtime/Model/Breadcrumbs/IBacktraceBreadcrumbs.cs
+++ b/Runtime/Model/Breadcrumbs/IBacktraceBreadcrumbs.cs
@@ -8,7 +8,7 @@ namespace Backtrace.Unity.Model.Breadcrumbs
     {
         BacktraceBreadcrumbType BreadcrumbsLevel { get; }
         bool EnableBreadcrumbs();
-        [Obsolete("Please use EnableBreadcurmbs instead. This function will be removed in the future updates")]
+        [Obsolete("Please use EnableBreadcrumbs instead. This function will be removed in the future updates")]
         bool EnableBreadcrumbs(BacktraceBreadcrumbType level, UnityEngineLogLevel unityLogLevel);
         bool ClearBreadcrumbs();
         bool Log(string message, LogType type, IDictionary<string, string> attributes);

--- a/Runtime/Native/Base.meta
+++ b/Runtime/Native/Base.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 906910b969566624aba683de2e0d0c6b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Native/Base/NativeClientBase.cs
+++ b/Runtime/Native/Base/NativeClientBase.cs
@@ -66,12 +66,23 @@ namespace Backtrace.Unity.Runtime.Native.Base
         public void Update(float time)
         {
             LastUpdateTime = time;
-            lock (_lockObject)
+            if (_shouldLogAnrsInBreadcrumbs && LogAnr)
             {
-                if (_shouldLogAnrsInBreadcrumbs && LogAnr)
+                if (Monitor.TryEnter(_lockObject))
                 {
-                    _breadcrumbs.AddBreadcrumbs(AnrMessage, BreadcrumbLevel.System, UnityEngineLogLevel.Warning);
-                    LogAnr = false;
+                    try
+                    {
+                        if (_shouldLogAnrsInBreadcrumbs && LogAnr)
+                        {
+                            _breadcrumbs.AddBreadcrumbs(AnrMessage, BreadcrumbLevel.System, UnityEngineLogLevel.Warning);
+                            LogAnr = false;
+                        }
+                    }
+                    finally
+                    {
+                        Monitor.Exit(_lockObject);
+                    }
+
                 }
             }
         }

--- a/Runtime/Native/Base/NativeClientBase.cs
+++ b/Runtime/Native/Base/NativeClientBase.cs
@@ -1,0 +1,116 @@
+﻿using Backtrace.Unity.Model;
+using Backtrace.Unity.Model.Breadcrumbs;
+using Backtrace.Unity.Extensions;
+using System.Threading;
+
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Backtrace.Unity.Tests.Runtime")]
+namespace Backtrace.Unity.Runtime.Native.Base
+{
+    internal abstract class NativeClientBase
+    {
+        internal const string AnrMessage = "ANRException: Blocked thread detected.";
+        protected const string HangType = "Hang";
+        protected const string CrashType = "Crash";
+        protected const string ErrorTypeAttribute = "error.type";
+
+        /// <summary>
+        /// Determine if ANR occurred and NativeClient should report ANR in breadcrumbs
+        /// </summary>
+        protected volatile bool LogAnr = false;
+
+        // Last Backtrace client update time 
+        protected volatile internal float LastUpdateTime;
+
+        /// <summary>
+        /// Determine if the ANR background thread should be disabled or not 
+        /// for some period of time.
+        /// This option will be used by the native client implementation
+        /// once application goes to background/foreground
+        /// </summary>
+        internal volatile bool PreventAnr = false;
+
+        /// <summary>
+        /// Determine if ANR thread should exit
+        /// </summary>
+        internal volatile bool StopAnr = false;
+
+        internal Thread AnrThread;
+
+        /// <summary>
+        /// Determine if Native client should capture native crashes
+        /// </summary>
+        protected bool CaptureNativeCrashes = false;
+
+        /// <summary>
+        /// Determine if Native client should handle ANRs
+        /// </summary>
+        protected bool HandlerANR = false;
+
+        protected readonly BacktraceConfiguration _configuration;
+        protected readonly BacktraceBreadcrumbs _breadcrumbs;
+
+        private readonly bool _shouldLogAnrsInBreadcrumbs;
+
+        private object _lockObject = new object();
+        internal NativeClientBase(BacktraceConfiguration configuration, BacktraceBreadcrumbs breadcrumbs)
+        {
+            _configuration = configuration;
+            _breadcrumbs = breadcrumbs;
+            _shouldLogAnrsInBreadcrumbs = ShouldStoreAnrBreadcrumbs();
+        }
+
+        /// <summary>
+        /// Update native client state
+        /// </summary>
+        /// <param name="time">Current game time</param>
+        public void Update(float time)
+        {
+            LastUpdateTime = time;
+            lock (_lockObject)
+            {
+                if (_shouldLogAnrsInBreadcrumbs && LogAnr)
+                {
+                    _breadcrumbs.AddBreadcrumbs(AnrMessage, BreadcrumbLevel.System, UnityEngineLogLevel.Warning);
+                    LogAnr = false;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Invoke code when ANR was detected
+        /// </summary>
+        internal void OnAnrDetection()
+        {
+            LogAnr = _shouldLogAnrsInBreadcrumbs;
+        }
+        /// <summary>
+        /// Pause ANR detection
+        /// </summary>
+        /// <param name="stopAnr">True - if native client should pause ANR detection"</param>
+        public void PauseAnrThread(bool stopAnr)
+        {
+            PreventAnr = stopAnr;
+        }
+
+        public virtual void Disable()
+        {
+            if (AnrThread != null)
+            {
+                StopAnr = true;
+            }
+        }
+
+        /// <summary>
+        /// Determine if native client should store ANR breadcrumbs
+        /// </summary>
+        /// <returns>True, if client should store ANR breadcrumbs. Otherwise false.</returns>
+        private bool ShouldStoreAnrBreadcrumbs()
+        {
+            if (_breadcrumbs == null)
+            {
+                return false;
+            }
+            return _breadcrumbs.BreadcrumbsLevel.HasFlag(BacktraceBreadcrumbType.System) && _breadcrumbs.UnityLogLevel.HasFlag(UnityEngineLogLevel.Warning);
+        }
+    }
+}

--- a/Runtime/Native/Base/NativeClientBase.cs.meta
+++ b/Runtime/Native/Base/NativeClientBase.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5a00ef4582ed50c4684565ef841bdc37
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Native/INativeClient.cs
+++ b/Runtime/Native/INativeClient.cs
@@ -10,7 +10,7 @@ namespace Backtrace.Unity.Runtime.Native
         /// <summary>
         /// Handle ANR - Application not responding events
         /// </summary>
-        void HandleAnr(string gameObjectName, string callbackName);
+        void HandleAnr();
 
         /// <summary>
         /// Set native attribute
@@ -28,7 +28,7 @@ namespace Backtrace.Unity.Runtime.Native
         /// <summary>
         /// Update native client internal ANR timer.
         /// </summary>
-        void UpdateClientTime(float time);
+        void Update(float time);
 
         /// <summary>
         /// Disable native integration

--- a/Runtime/Native/NativeClientFactory.cs
+++ b/Runtime/Native/NativeClientFactory.cs
@@ -1,18 +1,22 @@
 ﻿using Backtrace.Unity.Model;
+using Backtrace.Unity.Model.Breadcrumbs;
 using System.Collections.Generic;
 
 namespace Backtrace.Unity.Runtime.Native
 {
     internal static class NativeClientFactory
     {
-        internal static INativeClient CreateNativeClient(BacktraceConfiguration configuration, string gameObjectName, IDictionary<string, string> attributes, ICollection<string> attachments)
+        internal static INativeClient CreateNativeClient(BacktraceConfiguration configuration, string gameObjectName, BacktraceBreadcrumbs breadcrumbs, IDictionary<string, string> attributes, ICollection<string> attachments)
         {
 #if UNITY_STANDALONE_WIN
-            return new Windows.NativeClient(gameObjectName, configuration, attributes, attachments);
+            return new Windows.NativeClient(configuration, breadcrumbs, attributes, attachments);
 #elif UNITY_ANDROID
-            return new Android.NativeClient(gameObjectName, configuration, attributes, attachments);
+            return new Android.NativeClient(configuration, breadcrumbs, attributes, attachments)
+            {
+                GameObjectName = gameObjectName
+            };
 #elif UNITY_IOS
-            return new iOS.NativeClient(configuration, attributes, attachments);
+            return new iOS.NativeClient(configuration, breadcrumbs, attributes, attachments);
 #else
             return null;
 #endif

--- a/Runtime/Native/Windows/NativeClient.cs
+++ b/Runtime/Native/Windows/NativeClient.cs
@@ -1,7 +1,9 @@
 ﻿#if UNITY_STANDALONE_WIN
 using Backtrace.Unity.Interfaces;
 using Backtrace.Unity.Model;
+using Backtrace.Unity.Model.Breadcrumbs;
 using Backtrace.Unity.Model.Breadcrumbs.Storage;
+using Backtrace.Unity.Runtime.Native.Base;
 using Backtrace.Unity.Services;
 using Backtrace.Unity.Types;
 using System;
@@ -16,7 +18,7 @@ using UnityEngine;
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Backtrace.Unity.Tests.Runtime")]
 namespace Backtrace.Unity.Runtime.Native.Windows
 {
-    internal sealed class NativeClient : INativeClient
+    internal sealed class NativeClient : NativeClientBase, INativeClient
     {
         [Serializable]
         private class ScopedAttributesContainer
@@ -60,29 +62,8 @@ namespace Backtrace.Unity.Runtime.Native.Windows
         [DllImport("BacktraceCrashpadWindows", EntryPoint = "DumpWithoutCrash")]
         private static extern void NativeReport(string message, bool setMainThreadAsFaultingThread);
 
-        // Last Backtrace client update time 
-        volatile internal float _lastUpdateTime;
-
-        /// <summary>
-        /// Determine if the ANR background thread should be disabled or not 
-        /// for some period of time.
-        /// This option will be used by the native client implementation
-        /// once application goes to background/foreground
-        /// </summary>
-        volatile internal bool _preventAnr = false;
-
-        /// <summary>
-        /// Determine if ANR thread should exit
-        /// </summary>
-        volatile internal bool _stopAnr = false;
-
-        private Thread _anrThread;
-
-        private readonly BacktraceConfiguration _configuration;
-        private bool _captureNativeCrashes = false;
-        public NativeClient(string gameObjectName, BacktraceConfiguration configuration, IDictionary<string, string> clientAttributes, IEnumerable<string> attachments)
+        public NativeClient(BacktraceConfiguration configuration, BacktraceBreadcrumbs breadcrumbs, IDictionary<string, string> clientAttributes, IEnumerable<string> attachments) : base(configuration, breadcrumbs)
         {
-            _configuration = configuration;
             CleanScopedAttributes();
             HandleNativeCrashes(clientAttributes, attachments);
             AddScopedAttributes(clientAttributes);
@@ -94,8 +75,7 @@ namespace Backtrace.Unity.Runtime.Native.Windows
 
         private void HandleNativeCrashes(IDictionary<string, string> clientAttributes, IEnumerable<string> attachments)
         {
-            var integrationDisabled =
-                !_configuration.CaptureNativeCrashes || !_configuration.Enabled;
+            var integrationDisabled = !_configuration.CaptureNativeCrashes || !_configuration.Enabled;
             if (integrationDisabled)
             {
                 return;
@@ -121,14 +101,14 @@ namespace Backtrace.Unity.Runtime.Native.Windows
                 Directory.CreateDirectory(databasePath);
             }
 
-            _captureNativeCrashes = Initialize(
+            CaptureNativeCrashes = Initialize(
                 minidumpUrl,
                 databasePath,
                 crashpadHandlerPath,
                 attachments.ToArray(),
                 attachments.Count());
 
-            if (!_captureNativeCrashes)
+            if (!CaptureNativeCrashes)
             {
                 Debug.LogWarning("Backtrace native integration status: Cannot initialize Crashpad client");
                 return;
@@ -147,28 +127,18 @@ namespace Backtrace.Unity.Runtime.Native.Windows
             // don't add attributes that can change over the time to initialization method attributes. Crashpad will prevent from 
             // overriding them on game runtime. ANRs/OOMs methods can override error.type attribute, so we shouldn't pass error.type 
             // attribute via attributes parameters.
-            AddNativeAttribute("error.type", "Crash");
+            AddNativeAttribute(ErrorTypeAttribute, CrashType);
         }
-
-        public void Disable()
-        {
-            if (_anrThread != null)
-            {
-                _stopAnr = true;
-            }
-            return;
-        }
-
         public void GetAttributes(IDictionary<string, string> attributes)
         {
             return;
         }
 
-        public void HandleAnr(string gameObjectName = "", string callbackName = "")
+        public void HandleAnr()
         {
             var anrDisabled =
 #if UNITY_STANDALONE_WIN
-                !_captureNativeCrashes || !_configuration.HandleANR;
+                !CaptureNativeCrashes || !_configuration.HandleANR;
 #else
                 true;
 #endif
@@ -179,28 +149,29 @@ namespace Backtrace.Unity.Runtime.Native.Windows
 
             bool reported = false;
             var mainThreadId = Thread.CurrentThread.ManagedThreadId;
-            _anrThread = new Thread(() =>
+            AnrThread = new Thread(() =>
             {
                 float lastUpdatedCache = 0;
-                while (_anrThread.IsAlive && _stopAnr == false)
+                while (AnrThread.IsAlive && StopAnr == false)
                 {
-                    if (!_preventAnr)
+                    if (!PreventAnr)
                     {
                         if (lastUpdatedCache == 0)
                         {
-                            lastUpdatedCache = _lastUpdateTime;
+                            lastUpdatedCache = LastUpdateTime;
                         }
-                        else if (lastUpdatedCache == _lastUpdateTime)
+                        else if (lastUpdatedCache == LastUpdateTime)
                         {
                             if (!reported)
                             {
+                                OnAnrDetection();
                                 reported = true;
                                 // set temporary attribute to "Hang"
-                                AddNativeAttribute("error.type", "Hang");
+                                AddNativeAttribute(ErrorTypeAttribute, HangType);
 
-                                NativeReport("ANRException: Blocked thread detected.", true);
+                                NativeReport(AnrMessage, true);
                                 // update error.type attribute in case when crash happen 
-                                AddNativeAttribute("error.type", "Crash");
+                                AddNativeAttribute(ErrorTypeAttribute, HangType);
                             }
                         }
                         else
@@ -208,7 +179,7 @@ namespace Backtrace.Unity.Runtime.Native.Windows
                             reported = false;
                         }
 
-                        lastUpdatedCache = _lastUpdateTime;
+                        lastUpdatedCache = LastUpdateTime;
                     }
                     else if (lastUpdatedCache != 0)
                     {
@@ -219,19 +190,14 @@ namespace Backtrace.Unity.Runtime.Native.Windows
                     Thread.Sleep(5000);
                 }
             });
-            _anrThread.IsBackground = true;
-            _anrThread.Start();
+            AnrThread.IsBackground = true;
+            AnrThread.Start();
             return;
         }
 
         public bool OnOOM()
         {
             return false;
-        }
-
-        public void PauseAnrThread(bool state)
-        {
-            _preventAnr = state;
         }
 
         public void SetAttribute(string key, string value)
@@ -246,11 +212,6 @@ namespace Backtrace.Unity.Runtime.Native.Windows
                 value = string.Empty;
             }
             AddAttributes(key, value);
-        }
-
-        public void UpdateClientTime(float time)
-        {
-            _lastUpdateTime = time;
         }
 
         /// <summary>
@@ -296,7 +257,7 @@ namespace Backtrace.Unity.Runtime.Native.Windows
             IDictionary<string, string> attributes = GetScopedAttributes();
             // be sure that error.type attribute provided by default by our library
             // is always present in native attributes.
-            attributes["error.type"] = "Crash";
+            attributes[ErrorTypeAttribute] = CrashType;
 
             foreach (var crashDir in crashDirs)
             {
@@ -434,7 +395,7 @@ namespace Backtrace.Unity.Runtime.Native.Windows
         /// <param name="value">attribute value</param>
         private void AddAttributes(string key, string value)
         {
-            if (_captureNativeCrashes)
+            if (CaptureNativeCrashes)
             {
                 AddNativeAttribute(key, value);
             }

--- a/Runtime/Native/iOS/NativeClient.cs
+++ b/Runtime/Native/iOS/NativeClient.cs
@@ -6,6 +6,8 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Backtrace.Unity.Model;
+using Backtrace.Unity.Model.Breadcrumbs;
+using Backtrace.Unity.Runtime.Native.Base;
 using UnityEngine;
 
 namespace Backtrace.Unity.Runtime.Native.iOS
@@ -13,26 +15,8 @@ namespace Backtrace.Unity.Runtime.Native.iOS
     /// <summary>
     /// iOS native client 
     /// </summary>
-    internal class NativeClient : INativeClient
+    internal class NativeClient : NativeClientBase, INativeClient
     {
-        // Last Backtrace client update time 
-        volatile internal float _lastUpdateTime;
-
-        /// <summary>
-        /// Determine if the ANR background thread should be disabled or not 
-        /// for some period of time.
-        /// This option will be used by the native client implementation
-        /// once application goes to background/foreground
-        /// </summary>
-        volatile internal bool _preventAnr = false;
-
-        /// <summary>
-        /// Determine if ANR thread should exit
-        /// </summary>
-        volatile internal bool _stopAnr = false;
-
-        private Thread _anrThread;
-
         // NSDictinary entry used only for iOS native integration
         internal struct Entry
         {
@@ -68,22 +52,19 @@ namespace Backtrace.Unity.Runtime.Native.iOS
 
 #endif
 
-        public NativeClient(BacktraceConfiguration configuration, IDictionary<string, string> clientAttributes, ICollection<string> attachments)
+        public NativeClient(BacktraceConfiguration configuration, BacktraceBreadcrumbs breadcrumbs, IDictionary<string, string> clientAttributes, ICollection<string> attachments) : base(configuration, breadcrumbs)
         {
             if (INITIALIZED || !_enabled)
             {
                 return;
             }
-            if (configuration.CaptureNativeCrashes)
+            if (_configuration.CaptureNativeCrashes)
             {
-                HandleNativeCrashes(configuration, clientAttributes, attachments);
+                HandleNativeCrashes(clientAttributes, attachments);
                 INITIALIZED = true;
             }
-            if (configuration.HandleANR)
+            if (_configuration.HandleANR)
             {
-                // iOS integration doesn't require to pass game object name or callback function
-                // it's required by android to know which one object to call when ANR was detected 
-                // in Java. In this situation we simply ignore them.
                 HandleAnr();
             }
         }
@@ -93,9 +74,9 @@ namespace Backtrace.Unity.Runtime.Native.iOS
         /// Start crashpad process to handle native Android crashes
         /// </summary>
 
-        private void HandleNativeCrashes(BacktraceConfiguration configuration, IDictionary<string, string> attributes, IEnumerable<string> attachments)
+        private void HandleNativeCrashes(IDictionary<string, string> attributes, IEnumerable<string> attachments)
         {
-            var databasePath = configuration.GetFullDatabasePath();
+            var databasePath = _configuration.GetFullDatabasePath();
             // make sure database is enabled 
             if (string.IsNullOrEmpty(databasePath) || !Directory.Exists(databasePath))
             {
@@ -103,16 +84,16 @@ namespace Backtrace.Unity.Runtime.Native.iOS
                 return;
             }
 
-            var plcrashreporterUrl = new BacktraceCredentials(configuration.GetValidServerUrl()).GetPlCrashReporterSubmissionUrl();
+            var plcrashreporterUrl = new BacktraceCredentials(_configuration.GetValidServerUrl()).GetPlCrashReporterSubmissionUrl();
 
             // add exception.type attribute to PLCrashReporter reports
             // The library will send PLCrashReporter crashes to Backtrace
             // only when Crash occured
-            attributes["error.type"] = "Crash";
+            attributes[ErrorTypeAttribute] = CrashType;
             var attributeKeys = attributes.Keys.ToArray();
             var attributeValues = attributes.Values.ToArray();
 
-            Start(plcrashreporterUrl.ToString(), attributeKeys, attributeValues, attributeValues.Length, configuration.OomReports, attachments.ToArray(), attachments.Count());
+            Start(plcrashreporterUrl.ToString(), attributeKeys, attributeValues, attributeValues.Length, _configuration.OomReports, attachments.ToArray(), attachments.Count());
         }
 
         /// <summary>
@@ -154,7 +135,7 @@ namespace Backtrace.Unity.Runtime.Native.iOS
         /// <summary>
         /// Setup iOS ANR support and set callback function when ANR happened.
         /// </summary>
-        public void HandleAnr(string gameObjectName = "", string callbackName = "")
+        public void HandleAnr()
         {
             // if INITIALIZED is equal to false, plcrashreporter instance is disabled
             // so we can't generate native report
@@ -165,26 +146,27 @@ namespace Backtrace.Unity.Runtime.Native.iOS
 
             bool reported = false;
             var mainThreadId = Thread.CurrentThread.ManagedThreadId;
-            _anrThread = new Thread(() =>
+            AnrThread = new Thread(() =>
             {
                 float lastUpdatedCache = 0;
-                while (_anrThread.IsAlive && _stopAnr == false)
+                while (AnrThread.IsAlive && StopAnr == false)
                 {
-                    if (!_preventAnr)
+                    if (!PreventAnr)
                     {
                         if (lastUpdatedCache == 0)
                         {
-                            lastUpdatedCache = _lastUpdateTime;
+                            lastUpdatedCache = LastUpdateTime;
                         }
-                        else if (lastUpdatedCache == _lastUpdateTime)
+                        else if (lastUpdatedCache == LastUpdateTime)
                         {
                             if (!reported)
                             {
+                                OnAnrDetection();
                                 // set temporary attribute to "Hang"
-                                SetAttribute("error.type", "Hang");
-                                NativeReport("ANRException: Blocked thread detected.", true, true);
+                                SetAttribute(ErrorTypeAttribute, HangType);
+                                NativeReport(AnrMessage, true, true);
                                 // update error.type attribute in case when crash happen 
-                                SetAttribute("error.type", "Crash");
+                                SetAttribute(ErrorTypeAttribute, CrashType);
                                 reported = true;
                             }
                         }
@@ -194,7 +176,7 @@ namespace Backtrace.Unity.Runtime.Native.iOS
                         }
 
 
-                        lastUpdatedCache = _lastUpdateTime;
+                        lastUpdatedCache = LastUpdateTime;
                     }
                     else if (lastUpdatedCache != 0)
                     {
@@ -206,8 +188,8 @@ namespace Backtrace.Unity.Runtime.Native.iOS
 
                 }
             });
-            _anrThread.IsBackground = true;
-            _anrThread.Start();
+            AnrThread.IsBackground = true;
+            AnrThread.Start();
         }
 
 
@@ -249,35 +231,6 @@ namespace Backtrace.Unity.Runtime.Native.iOS
             // to avoid reporting low memory warning when application didn't crash 
             // native plugin will analyse previous application session             
             return true;
-        }
-
-        /// <summary>
-        /// Update native client internal timer.
-        /// </summary>
-        /// <param name="time">Current time</param>
-        public void UpdateClientTime(float time)
-        {
-            _lastUpdateTime = time;
-        }
-
-        /// <summary>
-        /// Disable native client integration
-        /// </summary>
-        public void Disable()
-        {
-            if (_anrThread != null)
-            {
-                _stopAnr = true;
-            }
-        }
-
-        /// <summary>
-        /// Pause ANR detection
-        /// </summary>
-        /// <param name="stopAnr">True - if native client should pause ANR detection"</param>
-        public void PauseAnrThread(bool stopAnr)
-        {
-            _preventAnr = stopAnr;
         }
     }
 }

--- a/Tests/Runtime/Breadcrumbs/BacktraceBreadcrumbsTypeTests.cs
+++ b/Tests/Runtime/Breadcrumbs/BacktraceBreadcrumbsTypeTests.cs
@@ -17,12 +17,12 @@ namespace Backtrace.Unity.Tests.Runtime.Breadcrumbs
             const string message = "message";
             const int expectedNumberOfLogs = 0;
             var inMemoryBreadcrumbStorage = new BacktraceInMemoryLogManager();
-            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage);
             //anything else than Manual
             var breadcrumbType = BacktraceBreadcrumbType.Configuration;
             UnityEngineLogLevel level = UnityEngineLogLevel.Debug | UnityEngineLogLevel.Error | UnityEngineLogLevel.Fatal | UnityEngineLogLevel.Info | UnityEngineLogLevel.Warning;
+            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage, breadcrumbType, level);
 
-            breadcrumbsManager.EnableBreadcrumbs(breadcrumbType, level);
+            breadcrumbsManager.EnableBreadcrumbs();
             var result = breadcrumbsManager.Log(message, testedLevel);
 
             Assert.IsFalse(result);
@@ -58,10 +58,10 @@ namespace Backtrace.Unity.Tests.Runtime.Breadcrumbs
         public void TestSystemLogs_ShouldEnableThem_EventsAreSet()
         {
             var inMemoryBreadcrumbStorage = new BacktraceInMemoryLogManager();
-            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage);
             UnityEngineLogLevel level = UnityEngineLogLevel.Debug | UnityEngineLogLevel.Error | UnityEngineLogLevel.Fatal | UnityEngineLogLevel.Info | UnityEngineLogLevel.Warning;
+            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage, BacktraceBreadcrumbType.System, level);
 
-            breadcrumbsManager.EnableBreadcrumbs(BacktraceBreadcrumbType.System, level);
+            breadcrumbsManager.EnableBreadcrumbs();
 
             Assert.IsTrue(breadcrumbsManager.EventHandler.HasRegisteredEvents);
             breadcrumbsManager.UnregisterEvents();
@@ -71,10 +71,10 @@ namespace Backtrace.Unity.Tests.Runtime.Breadcrumbs
         public void TestNavigationLogs_ShouldEnableThem_EventsAreSet()
         {
             var inMemoryBreadcrumbStorage = new BacktraceInMemoryLogManager();
-            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage);
             UnityEngineLogLevel level = UnityEngineLogLevel.Debug | UnityEngineLogLevel.Error | UnityEngineLogLevel.Fatal | UnityEngineLogLevel.Info | UnityEngineLogLevel.Warning;
+            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage, BacktraceBreadcrumbType.Navigation, level);
 
-            breadcrumbsManager.EnableBreadcrumbs(BacktraceBreadcrumbType.Navigation, level);
+            breadcrumbsManager.EnableBreadcrumbs();
 
             Assert.IsTrue(breadcrumbsManager.EventHandler.HasRegisteredEvents);
             breadcrumbsManager.UnregisterEvents();
@@ -84,10 +84,10 @@ namespace Backtrace.Unity.Tests.Runtime.Breadcrumbs
         public void TestLogLogs_ShouldEnableThem_EventsAreSet()
         {
             var inMemoryBreadcrumbStorage = new BacktraceInMemoryLogManager();
-            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage);
             UnityEngineLogLevel level = UnityEngineLogLevel.Debug | UnityEngineLogLevel.Error | UnityEngineLogLevel.Fatal | UnityEngineLogLevel.Info | UnityEngineLogLevel.Warning;
+            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage, BacktraceBreadcrumbType.Log, level);
 
-            breadcrumbsManager.EnableBreadcrumbs(BacktraceBreadcrumbType.Log, level);
+            breadcrumbsManager.EnableBreadcrumbs();
 
             Assert.IsTrue(breadcrumbsManager.EventHandler.HasRegisteredEvents);
             breadcrumbsManager.UnregisterEvents();

--- a/Tests/Runtime/Breadcrumbs/BreadcrumbsFileOperationTests.cs
+++ b/Tests/Runtime/Breadcrumbs/BreadcrumbsFileOperationTests.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using UnityEngine;
-using UnityEngine.TestTools;
 
 namespace Backtrace.Unity.Tests.Runtime.Breadcrumbs
 {
@@ -50,13 +49,14 @@ namespace Backtrace.Unity.Tests.Runtime.Breadcrumbs
             {
                 BreadcrumbFile = breadcrumbFile
             };
-            var breadcrumbsManager = new BacktraceBreadcrumbs(breadcrumbsStorageManager);
-            var unityEngineLogLevel = breadcrumbsManager.ConvertLogTypeToLogLevel(testedLevel);
+            var unityEngineLogLevel = BacktraceBreadcrumbs.ConvertLogTypeToLogLevel(testedLevel);
             var logTypeThatUnsupportCurrentTestCase =
               (Enum.GetValues(typeof(UnityEngineLogLevel)) as IEnumerable<UnityEngineLogLevel>)
               .First(n => n == unityEngineLogLevel);
+            var breadcrumbsManager = new BacktraceBreadcrumbs(breadcrumbsStorageManager, ManualBreadcrumbsType, logTypeThatUnsupportCurrentTestCase);
 
-            breadcrumbsManager.EnableBreadcrumbs(ManualBreadcrumbsType, logTypeThatUnsupportCurrentTestCase);
+
+            breadcrumbsManager.EnableBreadcrumbs();
             var added = breadcrumbsManager.Log(breadcrumbMessage, testedLevel);
 
             Assert.IsTrue(added);
@@ -81,11 +81,11 @@ namespace Backtrace.Unity.Tests.Runtime.Breadcrumbs
                 BreadcrumbFile = breadcrumbFile,
                 BreadcrumbsSize = minimalSize
             };
-            var breadcrumbsManager = new BacktraceBreadcrumbs(breadcrumbsStorageManager);
             var unityEngineLogLevel = UnityEngineLogLevel.Debug;
+            var breadcrumbsManager = new BacktraceBreadcrumbs(breadcrumbsStorageManager, ManualBreadcrumbsType, unityEngineLogLevel);
             var breadcrumbStart = breadcrumbsManager.BreadcrumbId();
 
-            breadcrumbsManager.EnableBreadcrumbs(ManualBreadcrumbsType, unityEngineLogLevel);
+            breadcrumbsManager.EnableBreadcrumbs();
             int numberOfAddedBreadcrumbs = 1;
             breadcrumbsManager.Log(breadcrumbMessage, LogType.Assert);
             var breadcrumbSize = breadcrumbFile.Size - 2;
@@ -124,11 +124,11 @@ namespace Backtrace.Unity.Tests.Runtime.Breadcrumbs
             {
                 BreadcrumbFile = breadcrumbFile
             };
-            var breadcrumbsManager = new BacktraceBreadcrumbs(breadcrumbsStorageManager);
-            var expectedBreadcrumbId = breadcrumbsManager.BreadcrumbId();
             var unityEngineLogLevel = UnityEngineLogLevel.Debug | UnityEngineLogLevel.Warning | UnityEngineLogLevel.Info | UnityEngineLogLevel.Error | UnityEngineLogLevel.Fatal;
+            var breadcrumbsManager = new BacktraceBreadcrumbs(breadcrumbsStorageManager, BacktraceBreadcrumbType.Manual | BacktraceBreadcrumbType.System, unityEngineLogLevel);
+            var expectedBreadcrumbId = breadcrumbsManager.BreadcrumbId();
 
-            breadcrumbsManager.EnableBreadcrumbs(BacktraceBreadcrumbType.Manual | BacktraceBreadcrumbType.System, unityEngineLogLevel);
+            breadcrumbsManager.EnableBreadcrumbs();
             breadcrumbsManager.Warning(messages[0], breadcrumb1Attributes);
             breadcrumbsManager.Info(messages[1]);
             breadcrumbsManager.Exception(messages[2]);

--- a/Tests/Runtime/Breadcrumbs/BreadcrumbsLogLevelTests.cs
+++ b/Tests/Runtime/Breadcrumbs/BreadcrumbsLogLevelTests.cs
@@ -22,13 +22,13 @@ namespace Backtrace.Unity.Tests.Runtime.Breadcrumbs
             const string message = "message";
             const int expectedNumberOfLogs = 0;
             var inMemoryBreadcrumbStorage = new BacktraceInMemoryLogManager();
-            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage);
-
             var logTypeThatUnsupportCurrentTestCase =
                 (Enum.GetValues(typeof(UnityEngineLogLevel)) as IEnumerable<UnityEngineLogLevel>)
-                .First(n => n != breadcrumbsManager.ConvertLogTypeToLogLevel(testedLevel));
+                .First(n => n != BacktraceBreadcrumbs.ConvertLogTypeToLogLevel(testedLevel));
 
-            breadcrumbsManager.EnableBreadcrumbs(ManualBreadcrumbsType, logTypeThatUnsupportCurrentTestCase);
+            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage, ManualBreadcrumbsType, logTypeThatUnsupportCurrentTestCase);
+
+            breadcrumbsManager.EnableBreadcrumbs();
 
             var result = breadcrumbsManager.Log(message, testedLevel);
 
@@ -46,13 +46,13 @@ namespace Backtrace.Unity.Tests.Runtime.Breadcrumbs
             const string message = "message";
             const int expectedNumberOfLogs = 1;
             var inMemoryBreadcrumbStorage = new BacktraceInMemoryLogManager();
-            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage);
-            var unityEngineLogLevel = breadcrumbsManager.ConvertLogTypeToLogLevel(testedLevel);
+            var unityEngineLogLevel = BacktraceBreadcrumbs.ConvertLogTypeToLogLevel(testedLevel);
             var logTypeThatUnsupportCurrentTestCase =
                 (Enum.GetValues(typeof(UnityEngineLogLevel)) as IEnumerable<UnityEngineLogLevel>)
                 .First(n => n == unityEngineLogLevel);
+            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage, ManualBreadcrumbsType, logTypeThatUnsupportCurrentTestCase);
 
-            breadcrumbsManager.EnableBreadcrumbs(ManualBreadcrumbsType, logTypeThatUnsupportCurrentTestCase);
+            breadcrumbsManager.EnableBreadcrumbs();
             var result = breadcrumbsManager.Log(message, testedLevel);
 
             Assert.IsTrue(result);
@@ -76,13 +76,14 @@ namespace Backtrace.Unity.Tests.Runtime.Breadcrumbs
             const string attributeValue = "bar";
             const int expectedNumberOfLogs = 1;
             var inMemoryBreadcrumbStorage = new BacktraceInMemoryLogManager();
-            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage);
-            var unityEngineLogLevel = breadcrumbsManager.ConvertLogTypeToLogLevel(testedLevel);
+            var unityEngineLogLevel = BacktraceBreadcrumbs.ConvertLogTypeToLogLevel(testedLevel);
             var logTypeThatUnsupportCurrentTestCase =
                 (Enum.GetValues(typeof(UnityEngineLogLevel)) as IEnumerable<UnityEngineLogLevel>)
                 .First(n => n == unityEngineLogLevel);
+            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage, ManualBreadcrumbsType, logTypeThatUnsupportCurrentTestCase);
 
-            breadcrumbsManager.EnableBreadcrumbs(ManualBreadcrumbsType, logTypeThatUnsupportCurrentTestCase);
+
+            breadcrumbsManager.EnableBreadcrumbs();
             var result = breadcrumbsManager.Log(message, testedLevel, new Dictionary<string, string>() { { attributeName, attributeValue } });
 
             Assert.IsTrue(result);
@@ -111,10 +112,10 @@ namespace Backtrace.Unity.Tests.Runtime.Breadcrumbs
             const string message = "message";
             const int expectedNumberOfLogs = 0;
             var inMemoryBreadcrumbStorage = new BacktraceInMemoryLogManager();
-            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage);
             var logTypeThatUnsupportCurrentTestCase = UnityEngineLogLevel.Error;
-            breadcrumbsManager.EnableBreadcrumbs(ManualBreadcrumbsType, logTypeThatUnsupportCurrentTestCase);
+            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage, ManualBreadcrumbsType, logTypeThatUnsupportCurrentTestCase);
 
+            breadcrumbsManager.EnableBreadcrumbs();
             var result = breadcrumbsManager.Debug(message);
 
             Assert.IsFalse(result);
@@ -127,9 +128,9 @@ namespace Backtrace.Unity.Tests.Runtime.Breadcrumbs
             const string message = "message";
             const int expectedNumberOfLogs = 1;
             var inMemoryBreadcrumbStorage = new BacktraceInMemoryLogManager();
-            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage);
             var supportedLogLevel = UnityEngineLogLevel.Debug;
-            breadcrumbsManager.EnableBreadcrumbs(ManualBreadcrumbsType, supportedLogLevel);
+            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage, ManualBreadcrumbsType, supportedLogLevel);
+            breadcrumbsManager.EnableBreadcrumbs();
 
             var result = breadcrumbsManager.Debug(message);
 
@@ -145,10 +146,10 @@ namespace Backtrace.Unity.Tests.Runtime.Breadcrumbs
             const string attributeValue = "bar";
             const int expectedNumberOfLogs = 1;
             var inMemoryBreadcrumbStorage = new BacktraceInMemoryLogManager();
-            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage);
             var supportedLogLevel = UnityEngineLogLevel.Debug;
+            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage, ManualBreadcrumbsType, supportedLogLevel);
 
-            breadcrumbsManager.EnableBreadcrumbs(ManualBreadcrumbsType, supportedLogLevel);
+            breadcrumbsManager.EnableBreadcrumbs();
             var result = breadcrumbsManager.Debug(message, new Dictionary<string, string>() { { attributeName, attributeValue } });
 
             Assert.IsTrue(result);
@@ -164,10 +165,10 @@ namespace Backtrace.Unity.Tests.Runtime.Breadcrumbs
             const string message = "message";
             const int expectedNumberOfLogs = 0;
             var inMemoryBreadcrumbStorage = new BacktraceInMemoryLogManager();
-            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage);
             var logTypeThatUnsupportCurrentTestCase = UnityEngineLogLevel.Error;
+            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage, ManualBreadcrumbsType, logTypeThatUnsupportCurrentTestCase);
 
-            breadcrumbsManager.EnableBreadcrumbs(ManualBreadcrumbsType, logTypeThatUnsupportCurrentTestCase);
+            breadcrumbsManager.EnableBreadcrumbs();
             var result = breadcrumbsManager.Warning(message);
 
             Assert.IsFalse(result);
@@ -180,10 +181,10 @@ namespace Backtrace.Unity.Tests.Runtime.Breadcrumbs
             const string message = "message";
             const int expectedNumberOfLogs = 1;
             var inMemoryBreadcrumbStorage = new BacktraceInMemoryLogManager();
-            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage);
             var supportedLogLevel = UnityEngineLogLevel.Warning;
-            breadcrumbsManager.EnableBreadcrumbs(ManualBreadcrumbsType, supportedLogLevel);
+            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage, ManualBreadcrumbsType, supportedLogLevel);
 
+            breadcrumbsManager.EnableBreadcrumbs();
             var result = breadcrumbsManager.Warning(message);
 
             Assert.IsTrue(result);

--- a/Tests/Runtime/Native/BreadcrumbsAnrTests.cs
+++ b/Tests/Runtime/Native/BreadcrumbsAnrTests.cs
@@ -1,0 +1,80 @@
+﻿using Backtrace.Unity.Model;
+using Backtrace.Unity.Model.Breadcrumbs;
+using Backtrace.Unity.Model.Breadcrumbs.InMemory;
+using Backtrace.Unity.Tests.Runtime.Native.Mocks;
+using NUnit.Framework;
+using System.Linq;
+using UnityEngine;
+
+namespace Backtrace.Unity.Tests.Runtime.Native
+{
+    public sealed class BreadcrumbsAnrTests
+    {
+        [Test]
+        public void TestAnrBreadcrumbReporting_ShouldAddAnrBreadcrumb_BreadcrumbSuccessfullyStored()
+        {
+            const int expectedNumberOfBreadcrumbs = 1;
+            var backtraceStorageManager = new BacktraceInMemoryLogManager();
+            var breadcrumbs = new BacktraceBreadcrumbs(backtraceStorageManager, BacktraceBreadcrumbType.System, UnityEngineLogLevel.Warning);
+            var configuration = ScriptableObject.CreateInstance<BacktraceConfiguration>();
+            var nativeClient = new TestableNativeClient(configuration, breadcrumbs);
+
+            nativeClient.SimulateAnr();
+            nativeClient.Update(0);
+
+            Assert.AreEqual(expectedNumberOfBreadcrumbs, breadcrumbs.LogManager.Length());
+            Assert.AreEqual(TestableNativeClient.AnrMessage, backtraceStorageManager.Breadcrumbs.First().Message);
+        }
+
+        [Test]
+        public void TestAnrBreadcrumbReporting_ShouldAddSingleAnrBreadcrumb_SingleBreadcrumbSuccessfullyStored()
+        {
+            const int expectedNumberOfBreadcrumbs = 1;
+            var backtraceStorageManager = new BacktraceInMemoryLogManager();
+            var breadcrumbs = new BacktraceBreadcrumbs(backtraceStorageManager, BacktraceBreadcrumbType.System, UnityEngineLogLevel.Warning);
+
+            var configuration = ScriptableObject.CreateInstance<BacktraceConfiguration>();
+            var nativeClient = new TestableNativeClient(configuration, breadcrumbs);
+
+            nativeClient.SimulateAnr();
+            nativeClient.Update(0);
+            nativeClient.Update(1);
+            nativeClient.Update(2);
+
+            Assert.AreEqual(expectedNumberOfBreadcrumbs, breadcrumbs.LogManager.Length());
+            Assert.AreEqual(TestableNativeClient.AnrMessage, backtraceStorageManager.Breadcrumbs.First().Message);
+        }
+
+        [Test]
+        public void TestAnrBreadcrumbReporting_ShouldIgnoreBreadcrumbsWithoutValidBreadcrumbType_NoBreadcrumbsStored()
+        {
+            const int expectedNumberOfBreadcrumbs = 0;
+            var notSupportedAnrBreadcrumbLevel = BacktraceBreadcrumbType.Log;
+            var backtraceStorageManager = new BacktraceInMemoryLogManager();
+            var breadcrumbs = new BacktraceBreadcrumbs(backtraceStorageManager, notSupportedAnrBreadcrumbLevel, UnityEngineLogLevel.Warning);
+            var configuration = ScriptableObject.CreateInstance<BacktraceConfiguration>();
+            var nativeClient = new TestableNativeClient(configuration, breadcrumbs);
+
+            nativeClient.SimulateAnr();
+            nativeClient.Update(0);
+
+            Assert.AreEqual(expectedNumberOfBreadcrumbs, breadcrumbs.LogManager.Length());
+        }
+
+        [Test]
+        public void TestAnrBreadcrumbReporting_ShouldIgnoreBreadcrumbsWithoutValidUnityLogLevel_NoBreadcrumbsStored()
+        {
+            const int expectedNumberOfBreadcrumbs = 0;
+            var notSupportedAnrUnityLogLevel = UnityEngineLogLevel.Debug;
+            var backtraceStorageManager = new BacktraceInMemoryLogManager();
+            var breadcrumbs = new BacktraceBreadcrumbs(backtraceStorageManager, BacktraceBreadcrumbType.System, notSupportedAnrUnityLogLevel);
+            var configuration = ScriptableObject.CreateInstance<BacktraceConfiguration>();
+            var nativeClient = new TestableNativeClient(configuration, breadcrumbs);
+
+            nativeClient.SimulateAnr();
+            nativeClient.Update(0);
+
+            Assert.AreEqual(expectedNumberOfBreadcrumbs, breadcrumbs.LogManager.Length());
+        }
+    }
+}

--- a/Tests/Runtime/Native/BreadcrumbsAnrTests.cs.meta
+++ b/Tests/Runtime/Native/BreadcrumbsAnrTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2dfb4a4b0168f1240bd89667ce6bf757
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/Native/Mocks.meta
+++ b/Tests/Runtime/Native/Mocks.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: da33a9d95baf9aa47a8323715d345842
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/Native/Mocks/TestableNativeClient.cs
+++ b/Tests/Runtime/Native/Mocks/TestableNativeClient.cs
@@ -1,0 +1,46 @@
+﻿using Backtrace.Unity.Model;
+using Backtrace.Unity.Model.Breadcrumbs;
+using Backtrace.Unity.Runtime.Native;
+using Backtrace.Unity.Runtime.Native.Base;
+using System.Collections.Generic;
+
+namespace Backtrace.Unity.Tests.Runtime.Native.Mocks
+{
+    internal sealed class TestableNativeClient : NativeClientBase, INativeClient
+    {
+        private readonly Dictionary<string, string> _attributes = new Dictionary<string, string>();
+
+        public TestableNativeClient(BacktraceConfiguration configuration, BacktraceBreadcrumbs breadcrumbs) : base(configuration, breadcrumbs)
+        { }
+
+        public void GetAttributes(IDictionary<string, string> attributes)
+        {
+            foreach (var attribute in _attributes)
+            {
+                attributes[attribute.Key] = attribute.Value;
+            }
+            return;
+        }
+
+        public void HandleAnr()
+        {
+            return;
+        }
+
+        public void SimulateAnr()
+        {
+            OnAnrDetection();
+        }
+
+        public bool OnOOM()
+        {
+            return true;
+        }
+
+        public void SetAttribute(string key, string value)
+        {
+            _attributes[key] = value;
+            return;
+        }
+    }
+}

--- a/Tests/Runtime/Native/Mocks/TestableNativeClient.cs.meta
+++ b/Tests/Runtime/Native/Mocks/TestableNativeClient.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2cf60b232d4b68d48b99dcaca74ec36a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/Native/Windows/ScopedNativeAttributesTests.cs
+++ b/Tests/Runtime/Native/Windows/ScopedNativeAttributesTests.cs
@@ -49,7 +49,7 @@ namespace Backtrace.Unity.Tests.Runtime.Native.Windows
             const string testAttributeString = "foo-key";
             const string testAttributeValue = "foo-bar-value";
 
-            new NativeClient("game-object-name", configuration, new Dictionary<string, string>() { { testAttributeString, testAttributeValue } }, new List<string>());
+            new NativeClient(configuration, null, new Dictionary<string, string>() { { testAttributeString, testAttributeValue } }, new List<string>());
             var scopedAttributes = NativeClient.GetScopedAttributes();
 
             Assert.AreEqual(scopedAttributes[testAttributeString], testAttributeValue);
@@ -70,7 +70,7 @@ namespace Backtrace.Unity.Tests.Runtime.Native.Windows
             const string testAttributeString = "foo-key";
             const string testAttributeValue = "foo-bar-value";
 
-            new NativeClient("game-object-name", configuration, new Dictionary<string, string>() { { testAttributeString, testAttributeValue } }, new List<string>());
+            new NativeClient(configuration, null, new Dictionary<string, string>() { { testAttributeString, testAttributeValue } }, new List<string>());
             var scopedAttributes = NativeClient.GetScopedAttributes();
 
             Assert.AreEqual(scopedAttributes["application.version"], testVersion);
@@ -88,7 +88,7 @@ namespace Backtrace.Unity.Tests.Runtime.Native.Windows
             const string testAttributeKey = "foo-key-bar-baz";
             const string testAttributeValue = "123123";
 
-            var client = new NativeClient("game-object-name", configuration, new Dictionary<string, string>(), new List<string>());
+            var client = new NativeClient(configuration, null, new Dictionary<string, string>(), new List<string>());
             client.SetAttribute(testAttributeKey, testAttributeValue);
             var scopedAttributes = NativeClient.GetScopedAttributes();
 
@@ -110,7 +110,7 @@ namespace Backtrace.Unity.Tests.Runtime.Native.Windows
             const string testAttributeString = "foo-key";
             const string testAttributeValue = "foo-bar-value";
 
-            new NativeClient("game-object-name", configuration, new Dictionary<string, string>() { { testAttributeString, testAttributeValue } }, new List<string>());
+            new NativeClient(configuration, null, new Dictionary<string, string>() { { testAttributeString, testAttributeValue } }, new List<string>());
             var attributesBeforeCleanup = NativeClient.GetScopedAttributes();
             NativeClient.CleanScopedAttributes();
             var attributesAfterCleanup = NativeClient.GetScopedAttributes();


### PR DESCRIPTION
# Why

This diff adds support for breadcrumbs log when ANR occurs. This diff also abstracts some logic from each native client and changes the way how BacktraceClient can initialize breadcrumbs integration. We need to know available options before we start native integration, so this requirement required us to rethink the way how we enable/start breadcrumbs integration.