### PR TITLE
Apply default when value is below limit

### DIFF
--- a/Editor/BacktraceConfigurationEditor.cs
+++ b/Editor/BacktraceConfigurationEditor.cs
@@ -32,9 +32,7 @@ namespace Backtrace.Unity.Editor
                 serializedObject.FindProperty("HandleUnhandledExceptions"),
                 new GUIContent(BacktraceConfigurationLabels.LABEL_HANDLE_UNHANDLED_EXCEPTION));
 
-            EditorGUILayout.PropertyField(
-                serializedObject.FindProperty("ReportPerMin"),
-                new GUIContent(BacktraceConfigurationLabels.LABEL_REPORT_PER_MIN));
+            DrawIntegerTextboxWithDefault("ReportPerMin", BacktraceConfigurationLabels.LABEL_REPORT_PER_MIN, 0, BacktraceConfiguration.DefaultReportPerMin, serializedObject);
 
             GUIStyle clientAdvancedSettingsFoldout = new GUIStyle(EditorStyles.foldout);
             showClientAdvancedSettings = EditorGUILayout.Foldout(showClientAdvancedSettings, "Client advanced settings", clientAdvancedSettingsFoldout);
@@ -62,10 +60,7 @@ namespace Backtrace.Unity.Editor
                 }
 
                 DrawMultiselectDropdown("ReportFilterType", reportFilterType, BacktraceConfigurationLabels.LABEL_REPORT_FILTER, serializedObject);
-
-                EditorGUILayout.PropertyField(
-                        serializedObject.FindProperty("NumberOfLogs"),
-                        new GUIContent(BacktraceConfigurationLabels.LABEL_NUMBER_OF_LOGS));
+                DrawIntegerTextboxWithDefault("NumberOfLogs", BacktraceConfigurationLabels.LABEL_NUMBER_OF_LOGS, 0, BacktraceConfiguration.DefaultNumberOfLogs, serializedObject);
 
                 EditorGUILayout.PropertyField(
                  serializedObject.FindProperty("PerformanceStatistics"),
@@ -79,16 +74,11 @@ namespace Backtrace.Unity.Editor
                     serializedObject.FindProperty("Sampling"),
                     new GUIContent(BacktraceConfigurationLabels.LABEL_SAMPLING));
 
-                SerializedProperty gameObjectDepth = serializedObject.FindProperty("GameObjectDepth");
-                EditorGUILayout.PropertyField(gameObjectDepth, new GUIContent(BacktraceConfigurationLabels.LABEL_GAME_OBJECT_DEPTH));
+                DrawIntegerTextboxWithDefault("GameObjectDepth", BacktraceConfigurationLabels.LABEL_GAME_OBJECT_DEPTH, -1, BacktraceConfiguration.DefaultGameObjectDepth, serializedObject);
 
-                if (gameObjectDepth.intValue < -1)
-                {
-                    EditorGUILayout.HelpBox("Please insert value greater or equal -1", MessageType.Error);
-                }
                 EditorGUILayout.PropertyField(
-                serializedObject.FindProperty("DisableInEditor"),
-                new GUIContent(BacktraceConfigurationLabels.DISABLE_IN_EDITOR));
+                    serializedObject.FindProperty("DisableInEditor"),
+                    new GUIContent(BacktraceConfigurationLabels.DISABLE_IN_EDITOR));
             }
 
 #if !UNITY_WEBGL
@@ -213,18 +203,12 @@ namespace Backtrace.Unity.Editor
                         serializedObject.FindProperty("GenerateScreenshotOnException"),
                         new GUIContent(BacktraceConfigurationLabels.LABEL_GENERATE_SCREENSHOT_ON_EXCEPTION));
 
-                    SerializedProperty maxRecordCount = serializedObject.FindProperty("MaxRecordCount");
-                    EditorGUILayout.PropertyField(maxRecordCount, new GUIContent(BacktraceConfigurationLabels.LABEL_MAX_REPORT_COUNT));
-
-                    SerializedProperty maxDatabaseSize = serializedObject.FindProperty("MaxDatabaseSize");
-                    EditorGUILayout.PropertyField(maxDatabaseSize, new GUIContent(BacktraceConfigurationLabels.LABEL_MAX_DATABASE_SIZE));
-
-                    SerializedProperty retryInterval = serializedObject.FindProperty("RetryInterval");
-                    EditorGUILayout.PropertyField(retryInterval, new GUIContent(BacktraceConfigurationLabels.LABEL_RETRY_INTERVAL));
+                    DrawIntegerTextboxWithDefault("MaxRecordCount", BacktraceConfigurationLabels.LABEL_MAX_REPORT_COUNT, 1, BacktraceConfiguration.DefaultMaxRecordCount, serializedObject);
+                    DrawIntegerTextboxWithDefault("MaxDatabaseSize", BacktraceConfigurationLabels.LABEL_MAX_DATABASE_SIZE, 0, BacktraceConfiguration.DefaultMaxDatabaseSize, serializedObject);
+                    DrawIntegerTextboxWithDefault("RetryInterval", BacktraceConfigurationLabels.LABEL_RETRY_INTERVAL, 1, BacktraceConfiguration.DefaultRetryInterval, serializedObject);
 
                     EditorGUILayout.LabelField("Backtrace database require at least one retry.");
-                    SerializedProperty retryLimit = serializedObject.FindProperty("RetryLimit");
-                    EditorGUILayout.PropertyField(retryLimit, new GUIContent(BacktraceConfigurationLabels.LABEL_RETRY_LIMIT));
+                    DrawIntegerTextboxWithDefault("RetryLimit", BacktraceConfigurationLabels.LABEL_RETRY_LIMIT, 0, BacktraceConfiguration.DefaultRetryLimit, serializedObject);
 
                     SerializedProperty retryOrder = serializedObject.FindProperty("RetryOrder");
                     EditorGUILayout.PropertyField(retryOrder, new GUIContent(BacktraceConfigurationLabels.LABEL_RETRY_ORDER));
@@ -232,6 +216,24 @@ namespace Backtrace.Unity.Editor
             }
 
             serializedObject.ApplyModifiedProperties();
+        }
+
+
+        /// <summary>
+        /// Draw the textbox control dedicated to unsigned integers and apply default if user passes negative value 
+        /// </summary>
+        /// <param name="propertyName">Backtrace configuration property name</param>
+        /// <param name="label">Property label</param>
+        /// <param name="defaultValue">Default value</param>
+        /// <param name="serializedObject">Configuration object</param>
+        private static void DrawIntegerTextboxWithDefault(string propertyName, string label, int minimumValue, int defaultValue, SerializedObject serializedObject)
+        {
+            var property = serializedObject.FindProperty(propertyName);
+            EditorGUILayout.PropertyField(property, new GUIContent(label));
+            if (property.intValue < minimumValue)
+            {
+                property.intValue = defaultValue;
+            }
         }
 
         /// <summary>

--- a/Editor/BacktraceDatabaseConfigurationEditor.cs
+++ b/Editor/BacktraceDatabaseConfigurationEditor.cs
@@ -23,7 +23,7 @@ namespace Backtrace.Unity.Editor
 #if UNITY_STANDALONE_WIN
             settings.MinidumpType = (MiniDumpType)EditorGUILayout.EnumFlagsField(BacktraceConfigurationLabels.LABEL_MINIDUMP_SUPPORT, settings.MinidumpType);
 #else
-           settings.MinidumpType = MiniDumpType.None;
+            settings.MinidumpType = MiniDumpType.None;
 
 #endif
 
@@ -37,12 +37,12 @@ namespace Backtrace.Unity.Editor
             settings.MaxRecordCount = EditorGUILayout.IntField(BacktraceConfigurationLabels.LABEL_MAX_REPORT_COUNT, settings.MaxRecordCount);
             if (settings.MaxRecordCount < 0)
             {
-                settings.MaxRecordCount = 0;
+                settings.MaxRecordCount = BacktraceConfiguration.DefaultMaxRecordCount;
             }
             settings.MaxDatabaseSize = EditorGUILayout.LongField(BacktraceConfigurationLabels.LABEL_MAX_DATABASE_SIZE, settings.MaxDatabaseSize);
             if (settings.MaxDatabaseSize < 0)
             {
-                settings.MaxDatabaseSize = 0;
+                settings.MaxDatabaseSize = BacktraceConfiguration.DefaultMaxDatabaseSize;
             }
 
 
@@ -51,7 +51,7 @@ namespace Backtrace.Unity.Editor
             settings.RetryLimit = EditorGUILayout.IntField(BacktraceConfigurationLabels.LABEL_RETRY_LIMIT, settings.RetryLimit);
             if (settings.RetryLimit < 0)
             {
-                settings.RetryLimit = 1;
+                settings.RetryLimit = BacktraceConfiguration.DefaultRetryLimit;
             }
             settings.RetryOrder = (RetryOrder)EditorGUILayout.EnumPopup(BacktraceConfigurationLabels.LABEL_RETRY_ORDER, settings.RetryOrder);
         }

--- a/Runtime/Model/BacktraceConfiguration.cs
+++ b/Runtime/Model/BacktraceConfiguration.cs
@@ -28,6 +28,14 @@ namespace Backtrace.Unity.Model
             UnityEngineLogLevel.Info |
             UnityEngineLogLevel.Warning;
 
+        public const int DefaultRetryLimit = 3;
+        public const int DefaultReportPerMin = 50;
+        public const int DefaultGameObjectDepth = -1;
+        public const int DefaultNumberOfLogs = 10;
+        public const int DefaultMaxRecordCount = 8;
+        public const int DefaultMaxDatabaseSize = 0;
+        public const int DefaultRetryInterval = 60;
+
         /// <summary>
         /// Backtrace server url
         /// </summary>
@@ -44,7 +52,7 @@ namespace Backtrace.Unity.Model
         /// Maximum number reports per minute
         /// </summary>
         [Tooltip("Reports per minute: Limits the number of reports the client will send per minutes. If set to 0, there is no limit. If set to a higher value and the value is reached, the client will not send any reports until the next minute. Default: 50")]
-        public int ReportPerMin = 50;
+        public int ReportPerMin = DefaultReportPerMin;
 
         /// <summary>
         /// "Disable error reporting integration in editor mode.
@@ -96,13 +104,13 @@ namespace Backtrace.Unity.Model
         /// Game object depth in Backtrace report
         /// </summary>
         [Tooltip("Allows developer to filter number of game object childrens in Backtrace report.")]
-        public int GameObjectDepth = -1;
+        public int GameObjectDepth = DefaultGameObjectDepth;
 
         /// <summary>
         /// Number of logs collected by Backtrace-Unity
         /// </summary>
         [Tooltip("Number of logs collected by Backtrace-Unity")]
-        public uint NumberOfLogs = 10;
+        public uint NumberOfLogs = DefaultNumberOfLogs;
 
         /// <summary>
         /// Flag that allows to include performance statistics in Backtrace report
@@ -261,23 +269,23 @@ namespace Backtrace.Unity.Model
         /// Maximum number of stored reports in Database. If value is equal to zero, then limit not exists
         /// </summary>
         [Tooltip("This is one of two limits you can impose for controlling the growth of the offline store. This setting is the maximum number of stored reports in database. If value is equal to zero, then limit not exists, When the limit is reached, the database will remove the oldest entries.")]
-        public int MaxRecordCount = 8;
+        public int MaxRecordCount = DefaultMaxRecordCount;
 
         /// <summary>
         /// Database size in MB
         /// </summary>
         [Tooltip("This is the second limit you can impose for controlling the growth of the offline store. This setting is the maximum database size in MB. If value is equal to zero, then size is unlimited, When the limit is reached, the database will remove the oldest entries.")]
-        public long MaxDatabaseSize;
+        public long MaxDatabaseSize = DefaultMaxDatabaseSize;
         /// <summary>
         /// How much seconds library should wait before next retry.
         /// </summary>
         [Tooltip("If the database is unable to send its record, this setting specifies how many seconds the library should wait between retries.")]
-        public int RetryInterval = 60;
+        public int RetryInterval = DefaultRetryInterval;
 
         /// <summary>
         /// Maximum number of retries
         [Tooltip("If the database is unable to send its record, this setting specifies the maximum number of retries before the system gives up.")]
-        public int RetryLimit = 3;
+        public int RetryLimit = DefaultRetryLimit;
 
         /// <summary>
         /// Retry order

--- a/Runtime/Model/Database/BacktraceDatabaseSettings.cs
+++ b/Runtime/Model/Database/BacktraceDatabaseSettings.cs
@@ -19,7 +19,7 @@ namespace Backtrace.Unity.Model.Database
 
             DatabasePath = databasePath;
             _configuration = configuration;
-            _retryInterval = configuration.RetryInterval >= 0 ? Convert.ToUInt32(_configuration.RetryInterval) : 60;
+            _retryInterval = configuration.RetryInterval > 0 ? (uint)_configuration.RetryInterval : BacktraceConfiguration.DefaultRetryInterval;
         }
         /// <summary>
         /// Directory path where reports and minidumps are stored

--- a/Runtime/Model/Database/BacktraceDatabaseSettings.cs
+++ b/Runtime/Model/Database/BacktraceDatabaseSettings.cs
@@ -9,6 +9,7 @@ namespace Backtrace.Unity.Model.Database
     public class BacktraceDatabaseSettings
     {
         private readonly BacktraceConfiguration _configuration;
+        private readonly uint _retryInterval;
         public BacktraceDatabaseSettings(string databasePath, BacktraceConfiguration configuration)
         {
             if (configuration == null || string.IsNullOrEmpty(databasePath))
@@ -18,6 +19,7 @@ namespace Backtrace.Unity.Model.Database
 
             DatabasePath = databasePath;
             _configuration = configuration;
+            _retryInterval = configuration.RetryInterval >= 0 ? Convert.ToUInt32(_configuration.RetryInterval) : 60;
         }
         /// <summary>
         /// Directory path where reports and minidumps are stored
@@ -68,7 +70,7 @@ namespace Backtrace.Unity.Model.Database
         {
             get
             {
-                return Convert.ToUInt32(_configuration.RetryInterval);
+                return _retryInterval;
             }
         }
 


### PR DESCRIPTION
# Why

This diff adds support for default values in the UI. Previously a user knew that when the user launched the game. Now, we gonna apply some default every time when a user sets an invalid value. This pattern reuses the Unity editor pattern for unsigned integers that are available on the UI. Since this is the public API to make sure it won't break, we didn't change the variable types.