### PR TITLE
Native client compilation issues in older .NET platforms

### DIFF
--- a/Runtime/Native/Android/NativeClient.cs
+++ b/Runtime/Native/Android/NativeClient.cs
@@ -119,9 +119,10 @@ namespace Backtrace.Unity.Runtime.Native.Android
         private AndroidJavaObject _unhandledExceptionWatcher;
 
         private readonly bool _enableClientSideUnwinding = false;
-        public string GameObjectName { get; internal set; } = BacktraceClient.DefaultBacktraceGameObjectName;
+        public string GameObjectName { get; internal set; }
         public NativeClient(BacktraceConfiguration configuration, BacktraceBreadcrumbs breadcrumbs, IDictionary<string, string> clientAttributes, IEnumerable<string> attachments) : base(configuration, breadcrumbs)
         {
+            GameObjectName = BacktraceClient.DefaultBacktraceGameObjectName;
             SetDefaultAttributeMaps();
             if (!_enabled)
             {

--- a/Runtime/Native/Windows/NativeClient.cs
+++ b/Runtime/Native/Windows/NativeClient.cs
@@ -1,6 +1,7 @@
 ﻿#if UNITY_STANDALONE_WIN
 using Backtrace.Unity.Interfaces;
 using Backtrace.Unity.Model;
+using Backtrace.Unity.Extensions;
 using Backtrace.Unity.Model.Breadcrumbs;
 using Backtrace.Unity.Model.Breadcrumbs.Storage;
 using Backtrace.Unity.Runtime.Native.Base;


### PR DESCRIPTION
# Why

This diff fixes compilation issues on specific native platforms in older .NET versions