### PR TITLE
Improvement/prevent duplicated anrs

### DIFF
--- a/Android/BacktraceANRWatchdog.java
+++ b/Android/BacktraceANRWatchdog.java
@@ -62,11 +62,11 @@ public class BacktraceANRWatchdog extends Thread {
     /**
      * Initialize new instance of BacktraceANRWatchdog with default timeout
      */
-    public BacktraceANRWatchdog(String gameObjectName, String methodName) {
+    public BacktraceANRWatchdog(String gameObjectName, String methodName, int anrTimeout) {
         Log.d(LOG_TAG, "Initializing ANR watchdog");
         this.methodName = methodName;
         this.gameObjectName = gameObjectName;
-        this.timeout = DEFAULT_ANR_TIMEOUT;
+        this.timeout = anrTimeout;
         this.debug = false;
         BacktraceANRWatchdog._instance = this;
         this.start();
@@ -77,6 +77,8 @@ public class BacktraceANRWatchdog extends Thread {
      */
     @Override
     public void run() {
+        Boolean reported = false;
+        Log.d(LOG_TAG, "Starting ANR watchdog. Anr timeout:" + this.timeout);
         while (!shouldStop && !isInterrupted()) {
             String dateTimeNow = Calendar.getInstance().getTime().toString();
             Log.d(LOG_TAG, "ANR WATCHDOG - " + dateTimeNow);
@@ -96,6 +98,7 @@ public class BacktraceANRWatchdog extends Thread {
             threadWatcher.tickPrivateCounter();
 
             if (threadWatcher.getCounter() == threadWatcher.getPrivateCounter()) {
+                reported = false;
                 Log.d(LOG_TAG, "ANR is not detected");
                 continue;
             }
@@ -105,6 +108,11 @@ public class BacktraceANRWatchdog extends Thread {
                         "is on and connected debugger");
                 continue;
             }
+            if(reported) {
+                // skipping, because we already reported an ANR report for current ANR
+                continue;
+            }
+            reported = true;
             NotifyUnityAboutANR();
         }
     }

--- a/Android/BacktraceANRWatchdog.java
+++ b/Android/BacktraceANRWatchdog.java
@@ -78,10 +78,9 @@ public class BacktraceANRWatchdog extends Thread {
     @Override
     public void run() {
         Boolean reported = false;
-        Log.d(LOG_TAG, "Starting ANR watchdog. Anr timeout:" + this.timeout);
+        Log.d(LOG_TAG, "Starting ANR watchdog. Anr timeout: " + this.timeout);
         while (!shouldStop && !isInterrupted()) {
             String dateTimeNow = Calendar.getInstance().getTime().toString();
-            Log.d(LOG_TAG, "ANR WATCHDOG - " + dateTimeNow);
             final backtrace.io.backtrace_unity_android_plugin.BacktraceThreadWatcher threadWatcher = new backtrace.io.backtrace_unity_android_plugin.BacktraceThreadWatcher(0, 0);
             mainThreadHandler.post(new Runnable() {
                 @Override
@@ -99,7 +98,6 @@ public class BacktraceANRWatchdog extends Thread {
 
             if (threadWatcher.getCounter() == threadWatcher.getPrivateCounter()) {
                 reported = false;
-                Log.d(LOG_TAG, "ANR is not detected");
                 continue;
             }
 
@@ -108,11 +106,12 @@ public class BacktraceANRWatchdog extends Thread {
                         "is on and connected debugger");
                 continue;
             }
-            if(reported) {
+            if (reported) {
                 // skipping, because we already reported an ANR report for current ANR
                 continue;
             }
             reported = true;
+            Log.d(LOG_TAG, "Detected blocked Java thread. Reporting Java ANR.");
             NotifyUnityAboutANR();
         }
     }

--- a/Android/BacktraceANRWatchdog.java
+++ b/Android/BacktraceANRWatchdog.java
@@ -21,11 +21,6 @@ public class BacktraceANRWatchdog extends Thread {
 
     private final static transient String LOG_TAG = BacktraceANRWatchdog.class.getSimpleName();
 
-    /**
-     * Default timeout value in milliseconds
-     */
-    private final static transient int DEFAULT_ANR_TIMEOUT = 5000;
-
 
     /**
      * Enable debug mode - errors will not be sent if the debugger is connected
@@ -136,5 +131,6 @@ public class BacktraceANRWatchdog extends Thread {
     public void stopMonitoring() {
         Log.d(LOG_TAG, "ANR handler has been disabled.");
         shouldStop = true;
+        BacktraceANRWatchdog._instance = null;
     }
 }

--- a/Runtime/Model/BacktraceConfiguration.cs
+++ b/Runtime/Model/BacktraceConfiguration.cs
@@ -28,6 +28,8 @@ namespace Backtrace.Unity.Model
             UnityEngineLogLevel.Info |
             UnityEngineLogLevel.Warning;
 
+        public const int DefaultAnrWatchdogTimeout = 5000;
+
         /// <summary>
         /// Backtrace server url
         /// </summary>
@@ -135,6 +137,11 @@ namespace Backtrace.Unity.Model
         /// </summary>
         [Tooltip("Capture ANR events - Application not responding")]
         public bool HandleANR = true;
+
+        /// <summary>
+        /// Anr watchdog timeout in ms. Time needed to detect an ANR event
+        /// </summary>
+        public int AnrWatchdogTimeout = DefaultAnrWatchdogTimeout;
 
 #if UNITY_ANDROID || UNITY_IOS
         /// <summary>

--- a/Runtime/Model/BacktraceResult.cs
+++ b/Runtime/Model/BacktraceResult.cs
@@ -114,20 +114,26 @@ namespace Backtrace.Unity.Model
 
         public static BacktraceResult FromJson(string json)
         {
-            if (string.IsNullOrEmpty(json))
-            {
-                return new BacktraceResult()
-                {
-                    Status = BacktraceResultStatus.Empty
-                };
-            }
-            var rawResult = JsonUtility.FromJson<BacktraceRawResult>(json);
             var result = new BacktraceResult()
             {
-                response = rawResult.response,
-                _rxId = rawResult._rxid,
-                Status = rawResult.response == "ok" ? BacktraceResultStatus.Ok : BacktraceResultStatus.ServerError
+                Status = string.IsNullOrEmpty(json) ? BacktraceResultStatus.Empty : BacktraceResultStatus.Ok
             };
+
+            if (result.Status == BacktraceResultStatus.Empty)
+            {
+                return result;
+            }
+
+            try
+            {
+                var rawResult = JsonUtility.FromJson<BacktraceRawResult>(json);
+                result.response = rawResult.response;
+                result._rxId = rawResult._rxid;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning(string.Format("Cannot parse Backtrace JSON response. Error: {0}. Content: {1}", json, e.Message));
+            }
             return result;
         }
 

--- a/Runtime/Native/Android/NativeClient.cs
+++ b/Runtime/Native/Android/NativeClient.cs
@@ -382,7 +382,7 @@ namespace Backtrace.Unity.Runtime.Native.Android
             }
             try
             {
-                _anrWatcher = new AndroidJavaObject(_anrPath, GameObjectName, CallbackMethodName);
+                _anrWatcher = new AndroidJavaObject(_anrPath, GameObjectName, CallbackMethodName, AnrWatchdogTimeout);
             }
             catch (Exception e)
             {
@@ -440,7 +440,7 @@ namespace Backtrace.Unity.Runtime.Native.Android
                         // we won't false positive ANR report
                         lastUpdatedCache = 0;
                     }
-                    Thread.Sleep(5000);
+                    Thread.Sleep(AnrWatchdogTimeout);
                 }
             });
             AnrThread.IsBackground = true;

--- a/Runtime/Native/Base/NativeClientBase.cs
+++ b/Runtime/Native/Base/NativeClientBase.cs
@@ -13,6 +13,7 @@ namespace Backtrace.Unity.Runtime.Native.Base
         protected const string CrashType = "Crash";
         protected const string ErrorTypeAttribute = "error.type";
 
+        protected int AnrWatchdogTimeout = 5000;
         /// <summary>
         /// Determine if ANR occurred and NativeClient should report ANR in breadcrumbs
         /// </summary>
@@ -57,6 +58,9 @@ namespace Backtrace.Unity.Runtime.Native.Base
             _configuration = configuration;
             _breadcrumbs = breadcrumbs;
             _shouldLogAnrsInBreadcrumbs = ShouldStoreAnrBreadcrumbs();
+            AnrWatchdogTimeout = configuration.AnrWatchdogTimeout > 1000
+                ? configuration.AnrWatchdogTimeout
+                : BacktraceConfiguration.DefaultAnrWatchdogTimeout;
         }
 
         /// <summary>

--- a/Runtime/Native/Base/NativeClientBase.cs
+++ b/Runtime/Native/Base/NativeClientBase.cs
@@ -13,7 +13,7 @@ namespace Backtrace.Unity.Runtime.Native.Base
         protected const string CrashType = "Crash";
         protected const string ErrorTypeAttribute = "error.type";
 
-        protected int AnrWatchdogTimeout = 5000;
+        protected int AnrWatchdogTimeout;
         /// <summary>
         /// Determine if ANR occurred and NativeClient should report ANR in breadcrumbs
         /// </summary>

--- a/Runtime/Native/Windows/NativeClient.cs
+++ b/Runtime/Native/Windows/NativeClient.cs
@@ -187,7 +187,7 @@ namespace Backtrace.Unity.Runtime.Native.Windows
                         // we won't false positive ANR report
                         lastUpdatedCache = 0;
                     }
-                    Thread.Sleep(5000);
+                    Thread.Sleep(AnrWatchdogTimeout);
                 }
             });
             AnrThread.IsBackground = true;

--- a/Runtime/Native/iOS/NativeClient.cs
+++ b/Runtime/Native/iOS/NativeClient.cs
@@ -188,7 +188,7 @@ namespace Backtrace.Unity.Runtime.Native.iOS
                         // we won't false positive ANR report
                         lastUpdatedCache = 0;
                     }
-                    Thread.Sleep(5000);
+                    Thread.Sleep(AnrWatchdogTimeout);
 
                 }
             });


### PR DESCRIPTION
# Why

This diff 
1. Prevents situation when android java thread stuck and android watchdog wants to report more than one ANR
2. make sure network communication is always right - when coronerd doesn't return expected message with status code 200 (service unavailable or something) we're still able to convert JSON to data without unhandled exception,
3. Configurable ANR watchdog options