### PR TITLE
Invalid background exception behavior

### DIFF
--- a/Android/BacktraceAndroidBackgroundUnhandledExceptionHandler.java
+++ b/Android/BacktraceAndroidBackgroundUnhandledExceptionHandler.java
@@ -16,8 +16,8 @@ public class BacktraceAndroidBackgroundUnhandledExceptionHandler implements Thre
     private final static transient String LOG_TAG = BacktraceAndroidBackgroundUnhandledExceptionHandler.class.getSimpleName();
     private final Thread.UncaughtExceptionHandler mRootHandler;
 
-    private Thread _exceptionThread;
-    private Throwable _backgroundException;
+    private Thread _lastCaughtBackgroundExceptionThread;
+    private Throwable _lastCaughtBackgroundException;
 
     /**
      * Check if data shouldn't be reported.
@@ -37,17 +37,17 @@ public class BacktraceAndroidBackgroundUnhandledExceptionHandler implements Thre
     }
 
     @Override
-    public void uncaughtException(final Thread thread, final Throwable exception) {
+    public void uncaughtException(final Thread thread, final Throwable throwable) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.CUPCAKE && mRootHandler != null && shouldStop == false) {
             if(Looper.getMainLooper().getThread().getId() == thread.getId()) {
                 // prevent from sending exception happened to main thread - we will catch them via unity logger
                 return;
             }
-            String exceptionType = exception.getClass().getName();
-            Log.d(LOG_TAG, "Detected unhandled background thread exception. Exception type: " + exceptionType + ". Reporting to Backtrace");
-            _exceptionThread = thread;
-            _backgroundException = exception;
-            ReportThreadException(exceptionType + " : " + exception.getMessage(), stackTraceToString(exception.getStackTrace()));
+            String throwableType = throwable.getClass().getName();
+            Log.d(LOG_TAG, "Detected unhandled background thread exception. Exception type: " + throwableType + ". Reporting to Backtrace");
+            _lastCaughtBackgroundExceptionThread = thread;
+            _lastCaughtBackgroundException = throwable;
+            ReportThreadException(throwableType + " : " + throwable.getMessage(), stackTraceToString(throwable.getStackTrace()));
         }
     }
 

--- a/Android/BacktraceAndroidBackgroundUnhandledExceptionHandler.java
+++ b/Android/BacktraceAndroidBackgroundUnhandledExceptionHandler.java
@@ -39,17 +39,15 @@ public class BacktraceAndroidBackgroundUnhandledExceptionHandler implements Thre
     @Override
     public void uncaughtException(final Thread thread, final Throwable exception) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.CUPCAKE && mRootHandler != null && shouldStop == false) {
-            if (exception instanceof Exception) {
-                if(Looper.getMainLooper().getThread().getId() == thread.getId()) {
-                    // prevent from sending exception happened to main thread - we will catch them via unity logger
-                    return;
-                }
-                String exceptionType = exception.getClass().getName();
-                Log.d(LOG_TAG, "Detected unhandled background thread exception. Exception type: " + exceptionType + ". Reporting to Backtrace");
-                _exceptionThread = thread;
-                _backgroundException = exception;
-                ReportThreadException(exceptionType + " : " + exception.getMessage(), stackTraceToString(exception.getStackTrace()));
+            if(Looper.getMainLooper().getThread().getId() == thread.getId()) {
+                // prevent from sending exception happened to main thread - we will catch them via unity logger
+                return;
             }
+            String exceptionType = exception.getClass().getName();
+            Log.d(LOG_TAG, "Detected unhandled background thread exception. Exception type: " + exceptionType + ". Reporting to Backtrace");
+            _exceptionThread = thread;
+            _backgroundException = exception;
+            ReportThreadException(exceptionType + " : " + exception.getMessage(), stackTraceToString(exception.getStackTrace()));
         }
     }
 

--- a/Android/BacktraceAndroidBackgroundUnhandledExceptionHandler.java
+++ b/Android/BacktraceAndroidBackgroundUnhandledExceptionHandler.java
@@ -16,6 +16,10 @@ public class BacktraceAndroidBackgroundUnhandledExceptionHandler implements Thre
     private final static transient String LOG_TAG = BacktraceAndroidBackgroundUnhandledExceptionHandler.class.getSimpleName();
     private final Thread.UncaughtExceptionHandler mRootHandler;
 
+    /** 
+    * Last caught background exception/thread that will be passed to the main thread when Unity notifies 
+    * that the C# layer stored the data in database/sent it to user
+    */
     private Thread _lastCaughtBackgroundExceptionThread;
     private Throwable _lastCaughtBackgroundException;
 
@@ -68,12 +72,12 @@ public class BacktraceAndroidBackgroundUnhandledExceptionHandler implements Thre
     }
 
     public void finish() {
-        if (_exceptionThread == null || _backgroundException == null) {
+        if (_lastCaughtBackgroundExceptionThread == null || _lastCaughtBackgroundException == null) {
             Log.d(LOG_TAG, "pass unhandled exception to the thread root handler, because exception thread/background thread doesn't exist");
             return;
         }
         Log.d(LOG_TAG, "The unhandled exception has been stored in the database.");
-        mRootHandler.uncaughtException(_exceptionThread, _backgroundException);
+        mRootHandler.uncaughtException(_lastCaughtBackgroundExceptionThread, _lastCaughtBackgroundException);
     }
 
     public void stopMonitoring() {

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -991,7 +991,19 @@ namespace Backtrace.Unity
             }
             var message = backgroundExceptionMessage.Substring(0, splitIndex);
             var stackTrace = backgroundExceptionMessage.Substring(splitIndex);
-            HandleUnityMessage(message, stackTrace, LogType.Exception);
+            if (Database != null)
+            {
+                Database.Add(new BacktraceReport(new BacktraceUnhandledException(message, stackTrace)).ToBacktraceData(null, GameObjectDepth));
+            }
+            else
+            {
+                HandleUnityMessage(message, stackTrace, LogType.Exception);
+            }
+            var androidNativeClient = _nativeClient as Runtime.Native.Android.NativeClient;
+            if (androidNativeClient != null)
+            {
+                androidNativeClient.FinishUnhandledBackgroundException();
+            }
         }
 #endif
 

--- a/Runtime/Native/Android/NativeClient.cs
+++ b/Runtime/Native/Android/NativeClient.cs
@@ -120,9 +120,9 @@ namespace Backtrace.Unity.Runtime.Native.Android
 
         private readonly bool _enableClientSideUnwinding = false;
         public string GameObjectName { get; internal set; }
-        public NativeClient(BacktraceConfiguration configuration, BacktraceBreadcrumbs breadcrumbs, IDictionary<string, string> clientAttributes, IEnumerable<string> attachments) : base(configuration, breadcrumbs)
+        public NativeClient(BacktraceConfiguration configuration, BacktraceBreadcrumbs breadcrumbs, IDictionary<string, string> clientAttributes, IEnumerable<string> attachments, string gameObjectName) : base(configuration, breadcrumbs)
         {
-            GameObjectName = BacktraceClient.DefaultBacktraceGameObjectName;
+            GameObjectName = gameObjectName;
             SetDefaultAttributeMaps();
             if (!_enabled)
             {
@@ -158,7 +158,7 @@ namespace Backtrace.Unity.Runtime.Native.Android
             const string callbackName = "HandleUnhandledExceptionsFromAndroidBackgroundThread";
             try
             {
-                _unhandledExceptionWatcher = new AndroidJavaObject(_unhandledExceptionPath, GameObjectName, callbackName);
+                _unhandledExceptionWatcher = new AndroidJavaObject(_unhandledExceptionPath, "Backtrace", callbackName);
             }
             catch (Exception e)
             {
@@ -372,6 +372,15 @@ namespace Backtrace.Unity.Runtime.Native.Android
             }
         }
 
+        public void FinishUnhandledBackgroundException()
+        {
+            if (_unhandledExceptionWatcher == null)
+            {
+                return;
+            }
+            _unhandledExceptionWatcher.Call("finish");
+        }
+
         /// <summary>
         /// Setup Android ANR support and set callback function when ANR happened.
         /// </summary>
@@ -488,8 +497,8 @@ namespace Backtrace.Unity.Runtime.Native.Android
         {
             if (CaptureNativeCrashes)
             {
-                CaptureNativeCrashes = false;
-                DisableNativeIntegration();
+               CaptureNativeCrashes = false;
+               DisableNativeIntegration();
             }
             if (_anrWatcher != null)
             {

--- a/Runtime/Native/NativeClientFactory.cs
+++ b/Runtime/Native/NativeClientFactory.cs
@@ -11,10 +11,7 @@ namespace Backtrace.Unity.Runtime.Native
 #if UNITY_STANDALONE_WIN
             return new Windows.NativeClient(configuration, breadcrumbs, attributes, attachments);
 #elif UNITY_ANDROID
-            return new Android.NativeClient(configuration, breadcrumbs, attributes, attachments)
-            {
-                GameObjectName = gameObjectName
-            };
+            return new Android.NativeClient(configuration, breadcrumbs, attributes, attachments, gameObjectName);
 #elif UNITY_IOS
             return new iOS.NativeClient(configuration, breadcrumbs, attributes, attachments);
 #else


### PR DESCRIPTION
# Why
In the past our java background exception handler prevented from passing the background thread exception information. Right now we're doing that so other handlers can handle it.