### PR TITLE
Avoid using unsupported property in not-native builds

### DIFF
--- a/Runtime/Native/Base/NativeClientBase.cs
+++ b/Runtime/Native/Base/NativeClientBase.cs
@@ -1,4 +1,5 @@
-﻿using Backtrace.Unity.Model;
+﻿#if UNITY_ANDROID || UNITY_IOS || UNITY_STANDALONE_WIN
+using Backtrace.Unity.Model;
 using Backtrace.Unity.Model.Breadcrumbs;
 using Backtrace.Unity.Extensions;
 using System.Threading;
@@ -58,11 +59,9 @@ namespace Backtrace.Unity.Runtime.Native.Base
             _configuration = configuration;
             _breadcrumbs = breadcrumbs;
             _shouldLogAnrsInBreadcrumbs = ShouldStoreAnrBreadcrumbs();
-#if UNITY_ANDROID || UNITY_IOS || UNITY_STANDALONE_WIN
             AnrWatchdogTimeout = configuration.AnrWatchdogTimeout > 1000
                 ? configuration.AnrWatchdogTimeout
                 : BacktraceConfiguration.DefaultAnrWatchdogTimeout;
-#endif
         }
 
         /// <summary>
@@ -131,3 +130,4 @@ namespace Backtrace.Unity.Runtime.Native.Base
         }
     }
 }
+#endif

--- a/Runtime/Native/Base/NativeClientBase.cs
+++ b/Runtime/Native/Base/NativeClientBase.cs
@@ -13,7 +13,7 @@ namespace Backtrace.Unity.Runtime.Native.Base
         protected const string CrashType = "Crash";
         protected const string ErrorTypeAttribute = "error.type";
 
-        protected int AnrWatchdogTimeout;
+        protected int AnrWatchdogTimeout = BacktraceConfiguration.DefaultAnrWatchdogTimeout;
         /// <summary>
         /// Determine if ANR occurred and NativeClient should report ANR in breadcrumbs
         /// </summary>
@@ -58,9 +58,11 @@ namespace Backtrace.Unity.Runtime.Native.Base
             _configuration = configuration;
             _breadcrumbs = breadcrumbs;
             _shouldLogAnrsInBreadcrumbs = ShouldStoreAnrBreadcrumbs();
+#if UNITY_ANDROID || UNITY_IOS || UNITY_STANDALONE_WIN
             AnrWatchdogTimeout = configuration.AnrWatchdogTimeout > 1000
                 ? configuration.AnrWatchdogTimeout
                 : BacktraceConfiguration.DefaultAnrWatchdogTimeout;
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
# Why

Avoid using Anr Watchdog timeout in native client base on not supported platforms.