### PR TITLE
Unity dynamic attributes

### DIFF
--- a/Runtime/Model/Attributes/ProcessAttributeProvider.cs
+++ b/Runtime/Model/Attributes/ProcessAttributeProvider.cs
@@ -24,6 +24,7 @@ namespace Backtrace.Unity.Model.Attributes
             attributes["mono.used"] = Profiler.GetMonoUsedSizeLong().ToString(CultureInfo.InvariantCulture);
             attributes["application.playing"] = Application.isPlaying.ToString(CultureInfo.InvariantCulture);
             attributes["application.focused"] = Application.isFocused.ToString(CultureInfo.InvariantCulture);
+            attributes["application.background"] = Application.runInBackground.ToString(CultureInfo.InvariantCulture);
             attributes["application.internet_reachability"] = Application.internetReachability.ToString();
 
         }

--- a/Runtime/Model/Attributes/ProcessAttributeProvider.cs
+++ b/Runtime/Model/Attributes/ProcessAttributeProvider.cs
@@ -22,6 +22,9 @@ namespace Backtrace.Unity.Model.Attributes
             attributes["system.memory.temp"] = Profiler.GetTempAllocatorSize().ToString(CultureInfo.InvariantCulture);
             attributes["mono.heap"] = Profiler.GetMonoHeapSizeLong().ToString(CultureInfo.InvariantCulture);
             attributes["mono.used"] = Profiler.GetMonoUsedSizeLong().ToString(CultureInfo.InvariantCulture);
+            attributes["application.playing"] = Application.isPlaying.ToString(CultureInfo.InvariantCulture);
+            attributes["application.focused"] = Application.isFocused.ToString(CultureInfo.InvariantCulture);
+            attributes["application.internet_reachability"] = Application.internetReachability.ToString();
 
         }
     }

--- a/Runtime/Model/Attributes/RuntimeAttributeProvider.cs
+++ b/Runtime/Model/Attributes/RuntimeAttributeProvider.cs
@@ -23,11 +23,8 @@ namespace Backtrace.Unity.Model.Attributes
             attributes["application.data_path"] = Application.dataPath;
             attributes["application.id"] = Application.identifier;
             attributes["application.installer.name"] = Application.installerName;
-            attributes["application.internet_reachability"] = Application.internetReachability.ToString();
-            attributes["application.editor"] = Application.isEditor.ToString(CultureInfo.InvariantCulture);
-            attributes["application.focused"] = Application.isFocused.ToString(CultureInfo.InvariantCulture);
-            attributes["application.mobile"] = Application.isMobilePlatform.ToString(CultureInfo.InvariantCulture);
-            attributes["application.playing"] = Application.isPlaying.ToString(CultureInfo.InvariantCulture);
+            attributes["application.editor"] = Application.isEditor.ToString(CultureInfo.InvariantCulture);            
+            attributes["application.mobile"] = Application.isMobilePlatform.ToString(CultureInfo.InvariantCulture);            
             attributes["application.background"] = Application.runInBackground.ToString(CultureInfo.InvariantCulture);
             attributes["application.sandboxType"] = Application.sandboxType.ToString();
             attributes["application.system.language"] = Application.systemLanguage.ToString();

--- a/Runtime/Model/Attributes/RuntimeAttributeProvider.cs
+++ b/Runtime/Model/Attributes/RuntimeAttributeProvider.cs
@@ -25,7 +25,6 @@ namespace Backtrace.Unity.Model.Attributes
             attributes["application.installer.name"] = Application.installerName;
             attributes["application.editor"] = Application.isEditor.ToString(CultureInfo.InvariantCulture);            
             attributes["application.mobile"] = Application.isMobilePlatform.ToString(CultureInfo.InvariantCulture);            
-            attributes["application.background"] = Application.runInBackground.ToString(CultureInfo.InvariantCulture);
             attributes["application.sandboxType"] = Application.sandboxType.ToString();
             attributes["application.system.language"] = Application.systemLanguage.ToString();
             attributes["application.unity.version"] = Application.unityVersion;


### PR DESCRIPTION
# Why

This diff moves attributes that might change over the time from scoped attributes loaded only once on the runtime startup to dynamic attributes loaded every time when Backtrace is going to create a report.