### PR TITLE
Adds a checkbox for iOS builds to enable client side unwinding.

### DIFF
--- a/Editor/BacktraceConfigurationEditor.cs
+++ b/Editor/BacktraceConfigurationEditor.cs
@@ -1,4 +1,4 @@
-using Backtrace.Unity.Model;
+﻿using Backtrace.Unity.Model;
 using Backtrace.Unity.Model.Breadcrumbs;
 using Backtrace.Unity.Types;
 using System;
@@ -156,12 +156,16 @@ namespace Backtrace.Unity.Editor
                         EditorGUILayout.PropertyField(
                             serializedObject.FindProperty("OomReports"),
                              new GUIContent(BacktraceConfigurationLabels.LABEL_HANDLE_OOM));
-#endif
 
-#if UNITY_2019_2_OR_NEWER && UNITY_ANDROID
+#if UNITY_2019_2_OR_NEWER
                         EditorGUILayout.PropertyField(
                             serializedObject.FindProperty("ClientSideUnwinding"),
                             new GUIContent(BacktraceConfigurationLabels.LABEL_ENABLE_CLIENT_SIDE_UNWINDING));
+#endif
+
+#endif
+
+#if UNITY_2019_2_OR_NEWER && UNITY_ANDROID
 
                         EditorGUILayout.PropertyField(
                            serializedObject.FindProperty("SymbolsUploadToken"),

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -24,7 +24,7 @@ namespace Backtrace.Unity
     /// </summary>
     public class BacktraceClient : MonoBehaviour, IBacktraceClient
     {
-        public const string VERSION = "3.7.5";
+        public const string VERSION = "3.7.6-preview.1";
         internal const string DefaultBacktraceGameObjectName = "BacktraceClient";
         public BacktraceConfiguration Configuration;
 

--- a/Runtime/Model/BacktraceConfiguration.cs
+++ b/Runtime/Model/BacktraceConfiguration.cs
@@ -1,4 +1,4 @@
-using Backtrace.Unity.Common;
+﻿using Backtrace.Unity.Common;
 using Backtrace.Unity.Model.Breadcrumbs;
 using Backtrace.Unity.Services;
 using Backtrace.Unity.Types;
@@ -156,15 +156,18 @@ namespace Backtrace.Unity.Model
         /// </summary>
         [Tooltip("Send Out of Memory exceptions to Backtrace")]
         public bool OomReports = false;
-#endif
 
-#if UNITY_2019_2_OR_NEWER && UNITY_ANDROID
+#if UNITY_2019_2_OR_NEWER
         /// <summary>
         /// Enable client side unwinding.
         /// </summary>
         [Tooltip("Enable client-side unwinding.")]
         public bool ClientSideUnwinding = false;
+#endif
 
+#endif
+
+#if UNITY_2019_2_OR_NEWER && UNITY_ANDROID
         /// <summary>
         /// Symbols upload token
         /// </summary>

--- a/Runtime/Native/iOS/NativeClient.cs
+++ b/Runtime/Native/iOS/NativeClient.cs
@@ -63,7 +63,7 @@ namespace Backtrace.Unity.Runtime.Native.iOS
             }
             if (_configuration.CaptureNativeCrashes)
             {
-                HandleNativeCrashes(clientAttributes, attachments, configuration.ClientSideUnwinding);
+                HandleNativeCrashes(clientAttributes, attachments);
                 INITIALIZED = true;
             }
             if (_configuration.HandleANR)
@@ -77,7 +77,7 @@ namespace Backtrace.Unity.Runtime.Native.iOS
         /// Start crashpad process to handle native Android crashes
         /// </summary>
 
-        private void HandleNativeCrashes(IDictionary<string, string> attributes, IEnumerable<string> attachments, bool enableClientSideUnwinding)
+        private void HandleNativeCrashes(IDictionary<string, string> attributes, IEnumerable<string> attachments)
         {
             var databasePath = _configuration.GetFullDatabasePath();
             // make sure database is enabled 
@@ -96,7 +96,7 @@ namespace Backtrace.Unity.Runtime.Native.iOS
             var attributeKeys = attributes.Keys.ToArray();
             var attributeValues = attributes.Values.ToArray();
 
-            Start(plcrashreporterUrl.ToString(), attributeKeys, attributeValues, attributeValues.Length, _configuration.OomReports, attachments.ToArray(), attachments.Count(), enableClientSideUnwinding);
+            Start(plcrashreporterUrl.ToString(), attributeKeys, attributeValues, attributeValues.Length, _configuration.OomReports, attachments.ToArray(), attachments.Count(), _configuration.ClientSideUnwinding);
             CaptureNativeCrashes = true;
         }
 

--- a/Runtime/Native/iOS/NativeClient.cs
+++ b/Runtime/Native/iOS/NativeClient.cs
@@ -1,4 +1,4 @@
-#if UNITY_IOS
+﻿#if UNITY_IOS
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -25,7 +25,7 @@ namespace Backtrace.Unity.Runtime.Native.iOS
         }
 
         [DllImport("__Internal", EntryPoint = "StartBacktraceIntegration")]
-        private static extern void Start(string plCrashReporterUrl, string[] attributeKeys, string[] attributeValues, int attributesSize, bool enableOomSupport, string[] attachments, int attachmentSize);
+        private static extern void Start(string plCrashReporterUrl, string[] attributeKeys, string[] attributeValues, int attributesSize, bool enableOomSupport, string[] attachments, int attachmentSize, bool enableClientSideUnwinding);
 
         [DllImport("__Internal", EntryPoint = "NativeReport")]
         private static extern void NativeReport(string message, bool setMainThreadAsFaultingThread, bool ignoreIfDebugger);
@@ -63,7 +63,7 @@ namespace Backtrace.Unity.Runtime.Native.iOS
             }
             if (_configuration.CaptureNativeCrashes)
             {
-                HandleNativeCrashes(clientAttributes, attachments);
+                HandleNativeCrashes(clientAttributes, attachments, configuration.ClientSideUnwinding);
                 INITIALIZED = true;
             }
             if (_configuration.HandleANR)
@@ -77,7 +77,7 @@ namespace Backtrace.Unity.Runtime.Native.iOS
         /// Start crashpad process to handle native Android crashes
         /// </summary>
 
-        private void HandleNativeCrashes(IDictionary<string, string> attributes, IEnumerable<string> attachments)
+        private void HandleNativeCrashes(IDictionary<string, string> attributes, IEnumerable<string> attachments, bool enableClientSideUnwinding)
         {
             var databasePath = _configuration.GetFullDatabasePath();
             // make sure database is enabled 
@@ -96,7 +96,7 @@ namespace Backtrace.Unity.Runtime.Native.iOS
             var attributeKeys = attributes.Keys.ToArray();
             var attributeValues = attributes.Values.ToArray();
 
-            Start(plcrashreporterUrl.ToString(), attributeKeys, attributeValues, attributeValues.Length, _configuration.OomReports, attachments.ToArray(), attachments.Count());
+            Start(plcrashreporterUrl.ToString(), attributeKeys, attributeValues, attributeValues.Length, _configuration.OomReports, attachments.ToArray(), attachments.Count(), enableClientSideUnwinding);
             CaptureNativeCrashes = true;
         }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "io.backtrace.unity",
   "displayName": "Backtrace",
-  "version": "3.7.5",
+  "version": "3.7.6-preview.1",
   "unity": "2017.1",
   "description": "Backtrace's integration with Unity games allows customers to capture and report handled and unhandled Unity exceptions to their Backtrace instance, instantly offering the ability to prioritize and debug software errors.",
   "keywords": [


### PR DESCRIPTION
A simple change that adds the "Enable client side unwinding" checkbox, available on Android, to iOS builds.

At this moment, the option is passed to the `NativeClient`'s `Start` method, but we need to wait for a native implementation of this feature. 