### PR TITLE
Bugfix/next session breadcrumbs path

### DIFF
--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -570,7 +570,6 @@ namespace Backtrace.Unity
                 }
                 _nativeClient = NativeClientFactory.CreateNativeClient(Configuration, name, _breadcrumbs, scopedAttributes, nativeAttachments);
                 AttributeProvider.AddDynamicAttributeProvider(_nativeClient);
-                Database.EnableBreadcrumbsSupport();
             }
         }
 

--- a/Runtime/BacktraceDatabase.cs
+++ b/Runtime/BacktraceDatabase.cs
@@ -622,7 +622,19 @@ namespace Backtrace.Unity
             {
                 return;
             }
-            var files = BacktraceDatabaseFileContext.GetRecords();
+            var files = BacktraceDatabaseFileContext.GetRecords().ToArray();
+            if(files.Length == 0)
+            {
+                return;
+            }
+            string breadcrumbPath = string.Empty;
+            string breadcrumbArchive = string.Empty;
+
+            if(Breadcrumbs != null)
+            {
+                breadcrumbPath = Breadcrumbs.GetBreadcrumbLogPath();
+                breadcrumbArchive = Breadcrumbs.Archi
+            }
             foreach (var file in files)
             {
                 var record = BacktraceDatabaseRecord.ReadFromFile(file);

--- a/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbs.cs
+++ b/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbs.cs
@@ -29,6 +29,7 @@ namespace Backtrace.Unity.Model.Breadcrumbs
         /// Determine if breadcrumbs are enabled
         /// </summary>
         private bool _enabled = false;
+
         public BacktraceBreadcrumbs(IBacktraceLogManager logManager, BacktraceBreadcrumbType level, UnityEngineLogLevel unityLogLevel)
         {
             BreadcrumbsLevel = level;
@@ -190,6 +191,11 @@ namespace Backtrace.Unity.Model.Breadcrumbs
         public static bool CanStoreBreadcrumbs(UnityEngineLogLevel logLevel, BacktraceBreadcrumbType backtraceBreadcrumbsLevel)
         {
             return backtraceBreadcrumbsLevel != BacktraceBreadcrumbType.None && logLevel != UnityEngineLogLevel.None;
+        }
+        public string Archive()
+        {
+            return LogManager.Archive()
+
         }
     }
 }

--- a/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbs.cs
+++ b/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbs.cs
@@ -192,9 +192,22 @@ namespace Backtrace.Unity.Model.Breadcrumbs
         {
             return backtraceBreadcrumbsLevel != BacktraceBreadcrumbType.None && logLevel != UnityEngineLogLevel.None;
         }
+        /// <summary>
+        /// Archives a breadcrumb file from the previous session.
+        /// </summary>
+        /// <returns>
+        /// Path to the archived breadcrumb library. 
+        /// If the operation failed then the method returns
+        /// an empty string.
+        /// </returns>
         public string Archive()
         {
-            return LogManager.Archive()
+            var breadcrumbArchiveManager = LogManager as IArchiveableBreadcrumbManager;
+            if (breadcrumbArchiveManager == null)
+            {
+                return string.Empty;
+            }
+            return breadcrumbArchiveManager.Archive();
 
         }
     }

--- a/Runtime/Model/Breadcrumbs/IArchiveableBreadcrumbManager.cs
+++ b/Runtime/Model/Breadcrumbs/IArchiveableBreadcrumbManager.cs
@@ -1,0 +1,11 @@
+﻿namespace Backtrace.Unity.Model.Breadcrumbs
+{
+    internal interface IArchiveableBreadcrumbManager
+    {
+        /// <summary>
+        /// Archive current breadcrumb file
+        /// </summary>
+        /// <returns>Path to the archived breadcurmb file if archiving process went successfully. Otherwise empty string.</returns>
+        string Archive();
+    }
+}

--- a/Runtime/Model/Breadcrumbs/IArchiveableBreadcrumbManager.cs.meta
+++ b/Runtime/Model/Breadcrumbs/IArchiveableBreadcrumbManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 11e0df6317b5a1e499757f8c0a743a58
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Model/Breadcrumbs/IBacktraceBreadcrumbs.cs
+++ b/Runtime/Model/Breadcrumbs/IBacktraceBreadcrumbs.cs
@@ -29,5 +29,6 @@ namespace Backtrace.Unity.Model.Breadcrumbs
         double BreadcrumbId();
         void UnregisterEvents();
         void Update();
+        string Archive();
     }
 }

--- a/Runtime/Model/Breadcrumbs/Storage/BacktraceStorageLogManager.cs
+++ b/Runtime/Model/Breadcrumbs/Storage/BacktraceStorageLogManager.cs
@@ -331,7 +331,8 @@ namespace Backtrace.Unity.Model.Breadcrumbs.Storage
                 return string.Empty;
             }
 
-            var copyPath = Path.Combine(_storagePath, string.Format("{0}-1", BreadcrumbLogFilePrefix));
+            const string archivePattern = "{0}-1";
+            var copyPath = Path.Combine(_storagePath, string.Format(archivePattern, BreadcrumbLogFilePrefix));
             if (File.Exists(copyPath))
             {
                 File.Delete(copyPath);

--- a/Runtime/Model/Breadcrumbs/Storage/BacktraceStorageLogManager.cs
+++ b/Runtime/Model/Breadcrumbs/Storage/BacktraceStorageLogManager.cs
@@ -333,11 +333,7 @@ namespace Backtrace.Unity.Model.Breadcrumbs.Storage
 
             const string archivePattern = "{0}-1";
             var copyPath = Path.Combine(_storagePath, string.Format(archivePattern, BreadcrumbLogFilePrefix));
-            if (File.Exists(copyPath))
-            {
-                File.Delete(copyPath);
-            }
-            File.Copy(BreadcrumbsFilePath, copyPath);
+            File.Copy(BreadcrumbsFilePath, copyPath, true);
             return copyPath;
         }
     }

--- a/Runtime/Model/Breadcrumbs/Storage/BacktraceStorageLogManager.cs
+++ b/Runtime/Model/Breadcrumbs/Storage/BacktraceStorageLogManager.cs
@@ -7,7 +7,7 @@ using System.IO;
 
 namespace Backtrace.Unity.Model.Breadcrumbs.Storage
 {
-    internal sealed class BacktraceStorageLogManager : IBacktraceLogManager
+    internal sealed class BacktraceStorageLogManager : IBacktraceLogManager, IArchiveableBreadcrumbManager
     {
         /// <summary>
         /// Path to the breadcrumbs file
@@ -86,6 +86,11 @@ namespace Backtrace.Unity.Model.Breadcrumbs.Storage
         /// </summary>
         private readonly Queue<long> _logSize = new Queue<long>();
 
+        /// <summary>
+        /// Breadcrumb storage directory
+        /// </summary>
+        private readonly string _storagePath;
+
         internal IBreadcrumbFile BreadcrumbFile { get; set; }
 
         public BacktraceStorageLogManager(string storagePath)
@@ -94,7 +99,8 @@ namespace Backtrace.Unity.Model.Breadcrumbs.Storage
             {
                 throw new ArgumentException("Breadcrumbs storage path is null or empty");
             }
-            BreadcrumbsFilePath = Path.Combine(storagePath, BreadcrumbLogFileName);
+            _storagePath = storagePath;
+            BreadcrumbsFilePath = Path.Combine(_storagePath, BreadcrumbLogFileName);
             BreadcrumbFile = new BreadcrumbFile(BreadcrumbsFilePath);
         }
 
@@ -316,6 +322,22 @@ namespace Backtrace.Unity.Model.Breadcrumbs.Storage
         public double BreadcrumbId()
         {
             return _breadcrumbId;
+        }
+
+        public string Archive()
+        {
+            if (!File.Exists(BreadcrumbsFilePath))
+            {
+                return string.Empty;
+            }
+
+            var copyPath = Path.Combine(_storagePath, string.Format("{0}-1", BreadcrumbLogFilePrefix));
+            if (File.Exists(copyPath))
+            {
+                File.Delete(copyPath);
+            }
+            File.Copy(BreadcrumbsFilePath, copyPath);
+            return copyPath;
         }
     }
 }


### PR DESCRIPTION
# Why

We discovered a problem with breadcrumb support when we finished the previous session. If the game can't send errors on the next session startup because the game is delayed because of the startup jobs, then we probably won't have a breadcrumb file associated with the report. This diff makes a copy of the existing breadcrumb file on the session startup and replaces the old path to the breadcrumb file with a new one. In addition, this diff also delays possible breadcrumbs that backtrace-unity will store. Because of that, we're sure that we won't override the breadcrumb file before making a copy.

This diff is really similar to the diff that I already submitted while ago. In this diff I only focus on the breadcrumb problem and this diff doesn't touch initialization order - so it will be much safer to land if earlier. 