### PR TITLE
Release 3.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Backtrace Unity Release Notes
 
+## Version 3.7.7
+
+New functionality
+- Improved machine identifier functionality - if default identifier methods fail, a new machine identifier will be stored in the internal storage and will stay the same between game restarts.
+
+Bugfixes
+- Fixed a problem with missing breadcrumbs  files in a database records after a game restart.
+- Fixed a problem with 00000000-0000-0000-0000-000000000000 guid on Xbox and other consoles
+
+Maintenance
+- Upgraded PlCrashReporter library
+
 ## Version 3.7.6
 
 New functionality

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 New functionality
 - Improved machine identifier functionality - if default identifier methods fail, a new machine identifier will be stored in the internal storage and will stay the same between game restarts.
+- Added a new attribute `application.package` that stores information about an application package id. 
 
 Bugfixes
 - Fixed a problem with missing breadcrumbs files in the database records after a game restart.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ New functionality
 - Improved machine identifier functionality - if default identifier methods fail, a new machine identifier will be stored in the internal storage and will stay the same between game restarts.
 
 Bugfixes
-- Fixed a problem with missing breadcrumbs  files in a database records after a game restart.
-- Fixed a problem with 00000000-0000-0000-0000-000000000000 guid on Xbox and other consoles
+- Fixed a problem with missing breadcrumbs files in the database records after a game restart.
+- Fixed a problem with 00000000-0000-0000-0000-000000000000 guid on Xbox and other consoles.
 
 Maintenance
-- Upgraded PlCrashReporter library
+- Upgraded the PLCrashReporter library.
 
 ## Version 3.7.6
 

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -24,7 +24,7 @@ namespace Backtrace.Unity
     /// </summary>
     public class BacktraceClient : MonoBehaviour, IBacktraceClient
     {
-        public const string VERSION = "3.7.7-preview.1";
+        public const string VERSION = "3.7.7-preview.2";
         internal const string DefaultBacktraceGameObjectName = "BacktraceClient";
         public BacktraceConfiguration Configuration;
 

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -24,7 +24,7 @@ namespace Backtrace.Unity
     /// </summary>
     public class BacktraceClient : MonoBehaviour, IBacktraceClient
     {
-        public const string VERSION = "3.7.6";
+        public const string VERSION = "3.7.7-preview.1";
         internal const string DefaultBacktraceGameObjectName = "BacktraceClient";
         public BacktraceConfiguration Configuration;
 

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -24,7 +24,7 @@ namespace Backtrace.Unity
     /// </summary>
     public class BacktraceClient : MonoBehaviour, IBacktraceClient
     {
-        public const string VERSION = "3.7.7-preview.2";
+        public const string VERSION = "3.7.7";
         internal const string DefaultBacktraceGameObjectName = "BacktraceClient";
         public BacktraceConfiguration Configuration;
 

--- a/Runtime/Model/Attributes/RuntimeAttributeProvider.cs
+++ b/Runtime/Model/Attributes/RuntimeAttributeProvider.cs
@@ -22,6 +22,7 @@ namespace Backtrace.Unity.Model.Attributes
             attributes["application.company.name"] = Application.companyName;
             attributes["application.data_path"] = Application.dataPath;
             attributes["application.id"] = Application.identifier;
+            attributes["application.package"] = Application.identifier;
             attributes["application.installer.name"] = Application.installerName;
             attributes["application.editor"] = Application.isEditor.ToString(CultureInfo.InvariantCulture);            
             attributes["application.mobile"] = Application.isMobilePlatform.ToString(CultureInfo.InvariantCulture);            

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "io.backtrace.unity",
   "displayName": "Backtrace",
-  "version": "3.7.6",
+  "version": "3.7.7-preview.1",
   "unity": "2017.1",
   "description": "Backtrace's integration with Unity games allows customers to capture and report handled and unhandled Unity exceptions to their Backtrace instance, instantly offering the ability to prioritize and debug software errors.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "io.backtrace.unity",
   "displayName": "Backtrace",
-  "version": "3.7.7-preview.2",
+  "version": "3.7.7",
   "unity": "2017.1",
   "description": "Backtrace's integration with Unity games allows customers to capture and report handled and unhandled Unity exceptions to their Backtrace instance, instantly offering the ability to prioritize and debug software errors.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "io.backtrace.unity",
   "displayName": "Backtrace",
-  "version": "3.7.7-preview.1",
+  "version": "3.7.7-preview.2",
   "unity": "2017.1",
   "description": "Backtrace's integration with Unity games allows customers to capture and report handled and unhandled Unity exceptions to their Backtrace instance, instantly offering the ability to prioritize and debug software errors.",
   "keywords": [


### PR DESCRIPTION
# Why

This diff contains changelog/library version updates.

# Test report
Goal: move from preview to general availability
Focus on: native functionality due to library updates

Test binary:
[BacktraceTestProject 3.zip](https://github.com/backtrace-labs/backtrace-unity/files/9376895/BacktraceTestProject.3.zip)
Test devices:

- [x] iPhone 11, iOS 15.5 (OOM, Crash, Unhandled exception)

No screenshots captured.

- [x] iPad Air 2, iOS 13.6.1 (OOM, Crash, Unhandled exception)
<img width="2005" alt="Screen Shot 2022-08-18 at 1 22 04 PM" src="https://user-images.githubusercontent.com/726645/185477192-9c254e0d-ba97-4c38-a058-2b6dce4320ac.png">

- [x] iPhone Touch 6, iOS 12.5.4
<img width="1717" alt="Screen Shot 2022-08-18 at 1 25 30 PM" src="https://user-images.githubusercontent.com/726645/185477817-1a88d656-d955-42f9-8b89-59115be14e46.png">

- [x] iPhone 7 Plus, iOS 14.8
<img width="1652" alt="Screen Shot 2022-08-18 at 1 29 03 PM" src="https://user-images.githubusercontent.com/726645/185478371-61fc7a8d-49ab-4298-8f4a-7eb4fb8bac53.png">

<img width="1451" alt="Screen Shot 2022-08-18 at 1 29 40 PM" src="https://user-images.githubusercontent.com/726645/185478501-b2d03d1e-5125-42c3-8d12-10ea3a7a5560.png">
