### PR TITLE
Support for unknown universe based on the URL

### DIFF
--- a/Runtime/Interfaces/IBacktraceClient.cs
+++ b/Runtime/Interfaces/IBacktraceClient.cs
@@ -64,12 +64,12 @@ namespace Backtrace.Unity.Interfaces
         /// <summary>
         /// Enable event aggregation support.
         /// </summary>
-        void EnableMetrics();
+        bool EnableMetrics();
 
         /// <summary>
         /// Enable event aggregation support.
         /// </summary>
-        void EnableMetrics(string uniqueEventsSubmissionUrl, string summedEventsSubmissionUrl, uint timeIntervalInSec, string uniqueEventName);
+        bool EnableMetrics(string uniqueEventsSubmissionUrl, string summedEventsSubmissionUrl, uint timeIntervalInSec, string uniqueEventName);
 #endif
     }
 }

--- a/Runtime/Model/BacktraceConfiguration.cs
+++ b/Runtime/Model/BacktraceConfiguration.cs
@@ -346,7 +346,8 @@ namespace Backtrace.Unity.Model
                 var domainIndex = submissionUrl.IndexOf(backtraceDomain);
                 if (domainIndex == -1)
                 {
-                    throw new ArgumentException("Invalid Backtrace url");
+                    // capture situation when the URL doesn't point to known Backtrace URL
+                    return null;
                 }
 
                 var uri = new UriBuilder(submissionUrl);


### PR DESCRIPTION
# Why

This diff allows to setup a crash-free session metrics without an exception for the on-premise customers. Right now if the universe name is invalid, we will disable the metrics integration and require a user to programmatically create it.