### PR TITLE
Determine library name based on the namespace/function name

### DIFF
--- a/Runtime/Model/BacktraceUnhandledException.cs
+++ b/Runtime/Model/BacktraceUnhandledException.cs
@@ -242,6 +242,19 @@ namespace Backtrace.Unity.Model
             {
                 stackFrame.FunctionName = frameString;
             }
+
+            if (!string.IsNullOrEmpty(stackFrame.FunctionName))
+            {
+                var libraryNameSeparator = stackFrame.FunctionName.IndexOf(':');
+                if (libraryNameSeparator != -1)
+                {
+                    stackFrame.Library = stackFrame.FunctionName.Substring(0, libraryNameSeparator).Trim();
+                    stackFrame.FunctionName = stackFrame.FunctionName.Substring(++libraryNameSeparator).Trim();
+                } else
+                {
+                    stackFrame.Library = "native";
+                }
+            }
             return stackFrame;
 
         }
@@ -411,6 +424,10 @@ namespace Backtrace.Unity.Model
                     {
                         result.Library = null;
                     }
+                }
+                if (string.IsNullOrEmpty(result.Library))
+                {
+                    result.Library = result.FunctionName.Substring(0, result.FunctionName.LastIndexOf(".", result.FunctionName.IndexOf("(")));
                 }
             }
             return result;

--- a/Tests/Runtime/BacktraceStackTraceTests.cs
+++ b/Tests/Runtime/BacktraceStackTraceTests.cs
@@ -517,8 +517,12 @@ namespace Backtrace.Unity.Tests.Runtime
         {
 
             var simpleFunctionName = "GetStacktrace";
-            var functionNameWithWrappedManagedPrefix = "UnityEngine.DebugLogHandler:Internal_Log";
-            var functioNamewithMonoJitCodePrefix = "ServerGameManager:SendInitialiseNetObjectToClient";
+            var libraryNameWithWrappedManagedPrefix = "UnityEngine.DebugLogHandler";
+            var functionNameWithWrappedManagedPrefix = "Internal_Log";
+            var stackFrameWithManagedPrefix = string.Format("{0}:{1}", libraryNameWithWrappedManagedPrefix, functionNameWithWrappedManagedPrefix);
+            var libraryNamewithMonoJitCodePrefix = "ServerGameManager";
+            var functioNamewithMonoJitCodePrefix = "SendInitialiseNetObjectToClient";
+            var stackFrameWithMonoJitCodePrefix = string.Format("{0}:{1}", libraryNamewithMonoJitCodePrefix, functioNamewithMonoJitCodePrefix);
             var jitStackTrace = string.Format(@"#0 {0} (int)
                  #1 DebugStringToFile(DebugStringToFileData const&)
                  #2 DebugLogHandler_CUSTOM_Internal_Log(LogType, LogOption, ScriptingBackendNativeStringPtrOpaque*, ScriptingBackendNativeObjectPtrOpaque*)
@@ -530,7 +534,7 @@ namespace Backtrace.Unity.Tests.Runtime
                  #8  (Mono JIT Code) FG.Common.UnityNetworkMessageHandler:HandleAndFreeInboundGameMessage (FG.Common.MessageEnvelope)
                  #9  (Mono JIT Code) FG.Common.UnityNetworkMessageHandler:PeekAndHandleMessage (UnityEngine.Networking.NetworkMessage,FG.Common.GameConnection)
                  #10  (Mono JIT Code) FG.Common.FG_UnityInternetNetworkManager:ServerHandleMessageReceived (UnityEngine.Networking.NetworkMessage)",
-                 simpleFunctionName, functionNameWithWrappedManagedPrefix, functioNamewithMonoJitCodePrefix);
+                 simpleFunctionName, stackFrameWithManagedPrefix, stackFrameWithMonoJitCodePrefix);
 
 
             var backtraceUnhandledException = new BacktraceUnhandledException("foo", jitStackTrace);
@@ -538,7 +542,9 @@ namespace Backtrace.Unity.Tests.Runtime
             Assert.AreEqual(11, backtraceUnhandledException.StackFrames.Count);
             Assert.AreEqual(backtraceUnhandledException.StackFrames[0].FunctionName, simpleFunctionName);
             Assert.AreEqual(backtraceUnhandledException.StackFrames[3].FunctionName, functionNameWithWrappedManagedPrefix);
+            Assert.AreEqual(backtraceUnhandledException.StackFrames[3].Library, libraryNameWithWrappedManagedPrefix);
             Assert.AreEqual(backtraceUnhandledException.StackFrames[4].FunctionName, functioNamewithMonoJitCodePrefix);
+            Assert.AreEqual(backtraceUnhandledException.StackFrames[4].Library, libraryNamewithMonoJitCodePrefix);
         }
 
         [Test]
@@ -565,6 +571,27 @@ namespace Backtrace.Unity.Tests.Runtime
                 Assert.AreEqual(BacktraceStackFrameType.Dotnet, frame.StackFrameType);
                 Assert.IsTrue(frame.FunctionName.StartsWith("Unity.Entities."));
             }
+        }
+        [Test]
+        public void LibraryName_ShouldCorrectlyFindLibraryNameOnProductionBuild_LibraryNameAvailable()
+        {
+            var defaultLibraryNamespace = "UnitTestLibrary";
+            var additionalLibraryName = "AdditionalLibraryName";
+            var genericLibraryName = "Generic+WithPlus";
+            var stackTrace = string.Format(@"{0}.{1}.get_PlayerResults () (at <00000000000000000000000000000000>:0)
+                {0}.{2}.DoSomething (Session.Parameter session, System.Boolean test) (at <00000000000000000000000000000000>:0)
+                {0}.Generator`2[TOwner,TSignal].ProcessSignal () (at <00000000000000000000000000000000>:0)
+                {0}.OtherGenerator`2[TOwner,TSignal].Update () (at <00000000000000000000000000000000>:0)
+                {0}.State.OnUpdate () (at <00000000000000000000000000000000>:0)
+                {0}.DifferentState.StateUpdate () (at <00000000000000000000000000000000>:0)
+                {0}.State+InnerState_Active.Update (Advanced.Parameter.State state) (at <00000000000000000000000000000000>:0)",
+                defaultLibraryNamespace, additionalLibraryName, genericLibraryName);
+
+            var backtraceUnhandledException = new BacktraceUnhandledException("foo", stackTrace);
+
+            Assert.AreEqual(backtraceUnhandledException.StackFrames[0].Library, string.Format("{0}.{1}", defaultLibraryNamespace, additionalLibraryName));
+            Assert.AreEqual(backtraceUnhandledException.StackFrames[1].Library, string.Format("{0}.{1}", defaultLibraryNamespace, genericLibraryName));
+
         }
 
         internal string ConvertStackTraceToString(List<SampleStackFrame> data)


### PR DESCRIPTION
# Why

In the past Backtrace-Unity did generate an empty library name if the source code information was empty OR provided pre-generated information like `<123123123: 0>` - no information about source code. 

Right now, backtrace-unity plugin will try to determine the library name based on the namespace