### PR TITLE
Unique event default attribute name

### DIFF
--- a/Runtime/Services/BacktraceMetrics.cs
+++ b/Runtime/Services/BacktraceMetrics.cs
@@ -233,7 +233,7 @@ namespace Backtrace.Unity.Services
         /// </summary>
         public void SendStartupEvent()
         {
-            _uniqueEventsSubmissionQueue.StartWithEvent(DefaultUniqueAttributeName);
+            _uniqueEventsSubmissionQueue.StartWithEvent(StartupUniqueAttributeName);
             _summedEventsSubmissionQueue.StartWithEvent(StartupEventName);
         }
 


### PR DESCRIPTION
# Why

This diff allows using of user-specific unique event attributes instead of using the default provided by the library