### PR TITLE
Use C# api to upload symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 Bugfixes
 - Fixed a duplicate identifier issue available in the generated xcode project.
 
+New functionality
+- Added support for uploading Android symbols files on OSes other than Windows.
+
 ## Version 3.8.1
 
 Bugfixes

--- a/Editor/Native/Android/SymbolsUpload.cs
+++ b/Editor/Native/Android/SymbolsUpload.cs
@@ -97,17 +97,17 @@ namespace Backtrace.Unity.Editor.Build
 #if NET_UNITY_4_8 || NET_STANDARD_2_0
                 System.IO.Compression.ZipFile.ExtractToDirectory(symbolsArchive, symbolsTmpDir);
 #else
-            var unpackProcess = new System.Diagnostics.Process()
-                {
-                    StartInfo = new System.Diagnostics.ProcessStartInfo
+                var unpackProcess = new System.Diagnostics.Process()
                     {
-                        WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden,
-                        FileName = "tar",
-                        Arguments = string.Format("-C {0} -xf {1}", symbolsTmpDir, symbolsArchive)
-                    }
-                };
-            unpackProcess.Start();
-            unpackProcess.WaitForExit();
+                        StartInfo = new System.Diagnostics.ProcessStartInfo
+                        {
+                            WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden,
+                            FileName = "tar",
+                            Arguments = string.Format("-C {0} -xf {1}", symbolsTmpDir, symbolsArchive)
+                        }
+                    };
+                unpackProcess.Start();
+                unpackProcess.WaitForExit();
 #endif
                 var files = Directory.GetFiles(symbolsTmpDir, "*.sym.so", SearchOption.AllDirectories);
                 foreach (var file in files)

--- a/Editor/Native/Android/SymbolsUpload.cs
+++ b/Editor/Native/Android/SymbolsUpload.cs
@@ -93,8 +93,11 @@ namespace Backtrace.Unity.Editor.Build
 
             try
             {
-#if !(NET_STANDARD_2_0 && NET_4_6)
-                var unpackProcess = new System.Diagnostics.Process()
+
+#if NET_UNITY_4_8 || NET_STANDARD_2_0
+                System.IO.Compression.ZipFile.ExtractToDirectory(symbolsArchive, symbolsTmpDir);
+#else
+            var unpackProcess = new System.Diagnostics.Process()
                 {
                     StartInfo = new System.Diagnostics.ProcessStartInfo
                     {
@@ -103,10 +106,8 @@ namespace Backtrace.Unity.Editor.Build
                         Arguments = string.Format("-C {0} -xf {1}", symbolsTmpDir, symbolsArchive)
                     }
                 };
-                unpackProcess.Start();
-                unpackProcess.WaitForExit();
-#else
-                System.IO.Compression.ZipFile.ExtractToDirectory(symbolsArchive, symbolsTmpDir);
+            unpackProcess.Start();
+            unpackProcess.WaitForExit();
 #endif
                 var files = Directory.GetFiles(symbolsTmpDir, "*.sym.so", SearchOption.AllDirectories);
                 foreach (var file in files)
@@ -115,7 +116,9 @@ namespace Backtrace.Unity.Editor.Build
                     File.Move(file, newName);
                 }
                 var backtraceSymbols = Path.Combine(Path.GetTempPath(), string.Format("backtrace-{0}-symbols.zip", Guid.NewGuid().ToString()));
-#if !(NET_STANDARD_2_0 && NET_4_6)
+#if NET_UNITY_4_8 || NET_STANDARD_2_0
+                System.IO.Compression.ZipFile.CreateFromDirectory(symbolsTmpDir, backtraceSymbols);
+#else
                 var zipProcess = new System.Diagnostics.Process()
                 {
                     StartInfo = new System.Diagnostics.ProcessStartInfo
@@ -127,8 +130,6 @@ namespace Backtrace.Unity.Editor.Build
                 };
                 zipProcess.Start();
                 zipProcess.WaitForExit();
-#else
-                System.IO.Compression.ZipFile.CreateFromDirectory(symbolsTmpDir, backtraceSymbols);
 #endif
                 return backtraceSymbols;
             }

--- a/Editor/Native/Android/SymbolsUpload.cs
+++ b/Editor/Native/Android/SymbolsUpload.cs
@@ -93,17 +93,7 @@ namespace Backtrace.Unity.Editor.Build
 
             try
             {
-                var unpackProcess = new System.Diagnostics.Process()
-                {
-                    StartInfo = new System.Diagnostics.ProcessStartInfo
-                    {
-                        WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden,
-                        FileName = "tar",
-                        Arguments = string.Format("-C {0} -xf {1}", symbolsTmpDir, symbolsArchive)
-                    }
-                };
-                unpackProcess.Start();
-                unpackProcess.WaitForExit();
+                System.IO.Compression.ZipFile.ExtractToDirectory(symbolsArchive, symbolsTmpDir);
                 var files = Directory.GetFiles(symbolsTmpDir, "*.sym.so", SearchOption.AllDirectories);
                 foreach (var file in files)
                 {
@@ -111,18 +101,7 @@ namespace Backtrace.Unity.Editor.Build
                     File.Move(file, newName);
                 }
                 var backtraceSymbols = Path.Combine(Path.GetTempPath(), string.Format("backtrace-{0}-symbols.zip", Guid.NewGuid().ToString()));
-
-                var zipProcess = new System.Diagnostics.Process()
-                {
-                    StartInfo = new System.Diagnostics.ProcessStartInfo
-                    {
-                        WindowStyle = System.Diagnostics.ProcessWindowStyle.Hidden,
-                        FileName = "tar",
-                        Arguments = string.Format("-czvf {0} {1}", backtraceSymbols, symbolsTmpDir)
-                    }
-                };
-                zipProcess.Start();
-                zipProcess.WaitForExit();
+                System.IO.Compression.ZipFile.CreateFromDirectory(symbolsTmpDir, backtraceSymbols);
                 return backtraceSymbols;
             }
             catch (Exception e)

--- a/Runtime/Model/BacktraceData.cs
+++ b/Runtime/Model/BacktraceData.cs
@@ -140,10 +140,10 @@ namespace Backtrace.Unity.Model
             var jObject = new BacktraceJObject(new Dictionary<string, string>()
             {
                 { "uuid", UuidString },
-                {"lang",  Lang },
-                {"langVersion", LangVersion },
-                {"agent",  Agent},
-                {"agentVersion", AgentVersion },
+                { "lang",  Lang },
+                { "langVersion", LangVersion },
+                { "agent",  Agent},
+                { "agentVersion", AgentVersion },
                 { "mainThread", MainThread},
             });
             jObject.Add("timestamp", Timestamp);

--- a/Runtime/Model/JsonData/Annotations.cs
+++ b/Runtime/Model/JsonData/Annotations.cs
@@ -110,9 +110,9 @@ namespace Backtrace.Unity.Model.JsonData
             {
                 annotations.Add("Exception properties", new BacktraceJObject(new Dictionary<string, string>()
                 {
-                    {"message",  Exception.Message },
-                    {"stackTrace",Exception.StackTrace},
-                    {"type", Exception.GetType().FullName },
+                    { "message",  Exception.Message },
+                    { "stackTrace",Exception.StackTrace},
+                    { "type", Exception.GetType().FullName },
                     { "source",Exception.Source },
                 }));
             }
@@ -179,14 +179,14 @@ namespace Backtrace.Unity.Model.JsonData
             return new BacktraceJObject(new Dictionary<string, string>()
             {
                 { "name",  gameObject.name},
-                {"isStatic", gameObject.isStatic.ToString(CultureInfo.InvariantCulture).ToLower() },
-                {"layer",  gameObject.layer.ToString(CultureInfo.InvariantCulture) },
-                {"transform.position", gameObject.transform.position.ToString()},
-                {"transform.rotation", gameObject.transform.rotation.ToString()},
-                {"tag",gameObject.tag},
-                {"activeInHierarchy", gameObject.activeInHierarchy.ToString(CultureInfo.InvariantCulture).ToLower()},
-                {"activeSelf",  gameObject.activeSelf.ToString(CultureInfo.InvariantCulture).ToLower() },
-                {"instanceId", gameObject.GetInstanceID().ToString(CultureInfo.InvariantCulture) },
+                { "isStatic", gameObject.isStatic.ToString(CultureInfo.InvariantCulture).ToLower() },
+                { "layer",  gameObject.layer.ToString(CultureInfo.InvariantCulture) },
+                { "transform.position", gameObject.transform.position.ToString()},
+                { "transform.rotation", gameObject.transform.rotation.ToString()},
+                { "tag",gameObject.tag},
+                { "activeInHierarchy", gameObject.activeInHierarchy.ToString(CultureInfo.InvariantCulture).ToLower()},
+                { "activeSelf",  gameObject.activeSelf.ToString(CultureInfo.InvariantCulture).ToLower() },
+                { "instanceId", gameObject.GetInstanceID().ToString(CultureInfo.InvariantCulture) },
                 { "parnetName", string.IsNullOrEmpty(parentName) ? "root object" : parentName }
             });
         }
@@ -195,10 +195,10 @@ namespace Backtrace.Unity.Model.JsonData
             return new BacktraceJObject(new Dictionary<string, string>()
             {
                 { "name",  gameObject.name},
-                {"transform.position", gameObject.transform.position.ToString()},
-                {"transform.rotation", gameObject.transform.rotation.ToString()},
-                {"tag",gameObject.tag},
-                {"instanceId", gameObject.GetInstanceID().ToString(CultureInfo.InvariantCulture) },
+                { "transform.position", gameObject.transform.position.ToString()},
+                { "transform.rotation", gameObject.transform.rotation.ToString()},
+                { "tag",gameObject.tag},
+                { "instanceId", gameObject.GetInstanceID().ToString(CultureInfo.InvariantCulture) },
                 { "parnetName", string.IsNullOrEmpty(parentName) ? "root object" : parentName }
             });
         }


### PR DESCRIPTION
This diff fixes the symbols archive - because of recent changes the command line tool we used to archive/modify symbols is not available. Now we're using pure C# API to do such a thing. 