### PR TITLE
Attributes normalization

### DIFF
--- a/Runtime/Model/Attributes/MachineAttributeProvider.cs
+++ b/Runtime/Model/Attributes/MachineAttributeProvider.cs
@@ -65,6 +65,7 @@ namespace Backtrace.Unity.Model.Attributes
                 attributes["device.sdk"] = version.GetStatic<int>("SDK_INT").ToString();
                 attributes["uname.version"] = version.GetStatic<string>("RELEASE").ToString();
             }
+            attributes["uname.fullname"] = Environment.OSVersion.Version.ToString();
 #else
             if (SystemInfo.systemMemorySize != 0)
             {
@@ -76,6 +77,7 @@ namespace Backtrace.Unity.Model.Attributes
 
 #if UNITY_IOS
             attributes["uname.version"] = UnityEngine.iOS.Device.systemVersion;
+            attributes["uname.fullname"] = Environment.OSVersion.Version.ToString();
 #endif
         }
         private void IncludeGraphicCardInformation(IDictionary<string, string> attributes)

--- a/Runtime/Model/Attributes/MachineAttributeProvider.cs
+++ b/Runtime/Model/Attributes/MachineAttributeProvider.cs
@@ -72,6 +72,11 @@ namespace Backtrace.Unity.Model.Attributes
                 attributes["vm.rss.size"] = (SystemInfo.systemMemorySize * 1048576L).ToString(CultureInfo.InvariantCulture);
             }
 #endif
+
+
+#if UNITY_IOS
+            attributes["uname.version"] = UnityEngine.iOS.Device.systemVersion;
+#endif
         }
         private void IncludeGraphicCardInformation(IDictionary<string, string> attributes)
         {

--- a/Runtime/Model/Attributes/MachineAttributeProvider.cs
+++ b/Runtime/Model/Attributes/MachineAttributeProvider.cs
@@ -32,7 +32,6 @@ namespace Backtrace.Unity.Model.Attributes
             //Operating system name = such as "windows"
             attributes["uname.sysname"] = SystemHelper.Name();
 
-            //The version of the operating system
             attributes["uname.version"] = Environment.OSVersion.Version.ToString();
             attributes["uname.fullname"] = SystemInfo.operatingSystem;
             attributes["uname.family"] = SystemInfo.operatingSystemFamily.ToString();
@@ -52,7 +51,21 @@ namespace Backtrace.Unity.Model.Attributes
 
             //The hostname of the crashing system.
             attributes["hostname"] = Environment.MachineName;
-#if !UNITY_ANDROID
+#if UNITY_ANDROID
+
+            using (var build = new AndroidJavaClass("android.os.Build"))
+            {
+                attributes["device.manufacturer"] = build.GetStatic<string>("MANUFACTURER").ToString();
+                attributes["device.brand"] = build.GetStatic<string>("BRAND").ToString();
+                attributes["device.product"] = build.GetStatic<string>("PRODUCT").ToString();
+            }
+
+            using (var version = new AndroidJavaClass("android.os.Build$VERSION"))
+            {
+                attributes["device.sdk"] = version.GetStatic<int>("SDK_INT").ToString();
+                attributes["uname.version"] = version.GetStatic<string>("RELEASE").ToString();
+            }
+#else
             if (SystemInfo.systemMemorySize != 0)
             {
                 //number of kilobytes that application is using.


### PR DESCRIPTION
# Why

Unity-specific attributes we were populating in unity were including kernel version rather than system version. Because of that, our users couldn't check what version of the OS is impacted.

This diff includes OS version now as an attribute