### PR TITLE
xbox native client: fixes output directory for minidumps

### DIFF
--- a/Runtime/Native/XBOX/NativeClient.cs
+++ b/Runtime/Native/XBOX/NativeClient.cs
@@ -19,28 +19,23 @@ namespace Backtrace.Unity.Runtime.Native.XBOX
 
     internal class NativeClient : NativeClientBase, INativeClient
     {
-        [DllImport("backtrace_native_xbox_mt.dll")]
-        private static extern bool BacktraceCrash();
-
-        [DllImport("backtrace_native_xbox_mt.dll")]
+        [DllImport("backtrace_native_xbox.dll")]
         private static extern bool BacktraceAddAttribute(
             [MarshalAs(UnmanagedType.LPWStr)] string name,
             [MarshalAs(UnmanagedType.LPWStr)] string value
         );
 
-        [DllImport("backtrace_native_xbox_mt.dll")]
+        [DllImport("backtrace_native_xbox.dll")]
         private static extern bool BacktraceAddFile(
             [MarshalAs(UnmanagedType.LPWStr)] string name,
             [MarshalAs(UnmanagedType.LPWStr)] string path
         );
 
-        [DllImport("backtrace_native_xbox_mt.dll")]
-        private static extern bool BacktraceSetUrl(
-            [MarshalAs(UnmanagedType.LPWStr)] string url
+        [DllImport("backtrace_native_xbox.dll")]
+        private static extern bool BacktraceNativeXboxInit(
+            [MarshalAs(UnmanagedType.LPWStr)] string url,
+            [MarshalAs(UnmanagedType.LPWStr)] string dump_path
         );
-
-        [DllImport("backtrace_native_xbox_mt.dll")]
-        private static extern bool BacktraceNativeInitialize();
 
         /// <summary>
         /// Determine if the XBOX integration should be enabled
@@ -111,7 +106,7 @@ namespace Backtrace.Unity.Runtime.Native.XBOX
             }
 
             var minidumpUrl = new BacktraceCredentials(_configuration.GetValidServerUrl()).GetMinidumpSubmissionUrl().ToString();
-            BacktraceSetUrl(minidumpUrl);
+            var dumpPath = _configuration.GetFullDatabasePath();
 
             foreach (var attachment in attachments)
             {
@@ -119,7 +114,7 @@ namespace Backtrace.Unity.Runtime.Native.XBOX
                 BacktraceAddFile(name, attachment);
             }
 
-            CaptureNativeCrashes = BacktraceNativeInitialize();
+            CaptureNativeCrashes = BacktraceNativeXboxInit(minidumpUrl, dumpPath);
 
             if (!CaptureNativeCrashes)
             {


### PR DESCRIPTION
Uses the updated API of backtrace_native_xbox.dll, previously backtrace_native_xbox_mt.dll, to specify a path for writing dump files. Prior to this commit, it was unpredictable as to whether a minidump could be written or not as the current directory of the process was (unintentionally) being used.

With this change, minidumps are written to the value specified by the configuration's database path is passed which, by default, is `Application.persistentDataPath`.

Removed unused exports, BacktraceCrash, used only for debugging, and BacktraceSetUrl, which was folded into BacktraceNativeXboxInit.

The change will require updating to the latest backtrace_native_xbox.dll.

[Internal Ref BT-509]