### PR TITLE
metrics: fix for pending jobs being delayed one or more frames

### DIFF
--- a/Runtime/Model/Metrics/MetricsSubmissionQueue.cs
+++ b/Runtime/Model/Metrics/MetricsSubmissionQueue.cs
@@ -138,13 +138,17 @@ namespace Backtrace.Unity.Model.Metrics
 
         public void SendPendingEvents(float time)
         {
-            for (int index = 0; index < _submissionJobs.Count; index++)
+            for (int index = 0; index < _submissionJobs.Count; )
             {
                 var submissionJob = _submissionJobs.ElementAt(index);
                 if (submissionJob.NextInvokeTime < time)
                 {
                     SendPayload(submissionJob.Events, submissionJob.NumberOfAttempts);
                     _submissionJobs.RemoveAt(index);
+                }
+                else
+                {
+                   index++;
                 }
             }
         }


### PR DESCRIPTION
The list of pending jobs was being traversed using an index that was unconditionally incremented, even after removing an item from the list. This could cause a job to be skipped in `SendPendingEvents`, at least until the next frame.

This was not a fatal error as any skipped jobs would be handled in the later calls to SendPendingEvents (next tick).

Noticed while auditing the code for a reported issue with dropped events.