### PR TITLE
metrics: retry submission on connection failure

### DIFF
--- a/Runtime/Model/Metrics/MetricsSubmissionQueue.cs
+++ b/Runtime/Model/Metrics/MetricsSubmissionQueue.cs
@@ -116,8 +116,11 @@ namespace Backtrace.Unity.Model.Metrics
                 {
                     OnRequestCompleted();
                 }
-                else if (statusCode > 501 && statusCode != 505)
+                else if (httpError == true || (statusCode > 501 && statusCode != 505))
                 {
+                    // Failed to communicate with server or received a 5xx response code. Retry
+                    // again at a later time, up to the configured number of maximum attempts.
+                    //
                     _numberOfDroppedRequests++;
                     if (attempts + 1 == BacktraceMetrics.MaxNumberOfAttempts)
                     {


### PR DESCRIPTION
Previously, only a subset protocol errors would be considered for retry when submitting metrics (summed or unique) to events.backtrace.io. This excluded, notably, a failure to connect to the server at all. If the device was offline at startup, for instance, then the "Application Launches" event would never get sent.

This commit changes the handling so that any network error will also go through the retry logic for submitting an event.