### PR TITLE
Editor guard - do not use native code in editor

### DIFF
--- a/Runtime/Model/Attributes/MachineAttributeProvider.cs
+++ b/Runtime/Model/Attributes/MachineAttributeProvider.cs
@@ -51,7 +51,7 @@ namespace Backtrace.Unity.Model.Attributes
 
             //The hostname of the crashing system.
             attributes["hostname"] = Environment.MachineName;
-#if UNITY_ANDROID
+#if UNITY_ANDROID && !UNITY_EDITOR
 
             using (var build = new AndroidJavaClass("android.os.Build"))
             {
@@ -75,7 +75,7 @@ namespace Backtrace.Unity.Model.Attributes
 #endif
 
 
-#if UNITY_IOS
+#if UNITY_IOS && !UNITY_EDITOR
             attributes["uname.version"] = UnityEngine.iOS.Device.systemVersion;
             attributes["uname.fullname"] = Environment.OSVersion.Version.ToString();
 #endif


### PR DESCRIPTION
# Why

Last patch, we moved attributes generation outside the native client. The native client code was guarded, to be sure we won't execute the code in the editor, however `MachineAttributeProvider` isn't. This diff guards android/ios specific code to be only executed on iOS/Android 


refs: BT-1031