### PR TITLE
Added the screencapture module as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "url": "https://backtrace.io/"
   },
   "category": "Editor plugin + Script plugin",
-  "type": "library"
+  "type": "library",
+  "dependencies": {
+    "com.unity.modules.screencapture": "1.0.0"
+  }
 }


### PR DESCRIPTION
The package actually needs the screen capture module to be present and while that is included in manifest.json by default, it can be removed