### PR TITLE
Xbox native client improvements

### DIFF
--- a/Runtime/Model/Attributes/RuntimeAttributeProvider.cs
+++ b/Runtime/Model/Attributes/RuntimeAttributeProvider.cs
@@ -13,6 +13,7 @@ namespace Backtrace.Unity.Model.Attributes
                 return;
             }
 
+            attributes["backtrace.agent"] = "backtrace-unity";
             attributes["backtrace.version"] = BacktraceClient.VERSION;
             attributes["api.compatibility"] = GetApiCompatibility();
             attributes["scripting.backend"] = GetScriptingBackend();
@@ -24,8 +25,8 @@ namespace Backtrace.Unity.Model.Attributes
             attributes["application.id"] = Application.identifier;
             attributes["application.package"] = Application.identifier;
             attributes["application.installer.name"] = Application.installerName;
-            attributes["application.editor"] = Application.isEditor.ToString(CultureInfo.InvariantCulture);            
-            attributes["application.mobile"] = Application.isMobilePlatform.ToString(CultureInfo.InvariantCulture);            
+            attributes["application.editor"] = Application.isEditor.ToString(CultureInfo.InvariantCulture);
+            attributes["application.mobile"] = Application.isMobilePlatform.ToString(CultureInfo.InvariantCulture);
             attributes["application.sandboxType"] = Application.sandboxType.ToString();
             attributes["application.system.language"] = Application.systemLanguage.ToString();
             attributes["application.unity.version"] = Application.unityVersion;

--- a/Runtime/Native/XBOX/NativeClient.cs
+++ b/Runtime/Native/XBOX/NativeClient.cs
@@ -108,6 +108,11 @@ namespace Backtrace.Unity.Runtime.Native.XBOX
             var minidumpUrl = new BacktraceCredentials(_configuration.GetValidServerUrl()).GetMinidumpSubmissionUrl().ToString();
             var dumpPath = _configuration.GetFullDatabasePath();
 
+            if (string.IsNullOrEmpty(dumpPath) || !Directory.Exists(dumpPath))
+            {
+                Debug.LogWarning("Backtrace native integration status: database path doesn't exist");
+                return;
+            }
             CaptureNativeCrashes = BacktraceNativeXboxInit(minidumpUrl, dumpPath);
 
             if (!CaptureNativeCrashes)


### PR DESCRIPTION
# Why

In the xbox native client implementation, we have found a few places that require adjustments. This code makes sure:
- the error.type attribute is set like in every other native client implementation
- attributes are set only when the client is enabled,
- the integration is starting when the database directory exists. 