### PR TITLE
Report all throwable types, no matter if throwable is type error or not

### DIFF
--- a/Android/BacktraceAndroidBackgroundUnhandledExceptionHandler.java
+++ b/Android/BacktraceAndroidBackgroundUnhandledExceptionHandler.java
@@ -48,14 +48,10 @@ public class BacktraceAndroidBackgroundUnhandledExceptionHandler implements Thre
             finish();
             return;
         }
-        if (throwable instanceof Exception) {
-            String throwableType = throwable.getClass().getName();
-            Log.d(LOG_TAG, "Detected unhandled background thread exception. Exception type: " + throwableType + ". Reporting to Backtrace");
-            ReportThreadException(throwableType + " : " + throwable.getMessage(), stackTraceToString(throwable.getStackTrace()));
-        } else {
-            Log.d(LOG_TAG, "Detected android crash. Using native crash reporter to report an error.");
-            finish();
-        }
+        String throwableType = throwable.getClass().getName();
+        Log.d(LOG_TAG, "Detected unhandled background thread exception. Exception type: " + throwableType + ". Reporting to Backtrace");
+        ReportThreadException(throwableType + " : " + throwable.getMessage(), stackTraceToString(throwable.getStackTrace()));
+        finish();
     }
 
     public void ReportThreadException(String message, String stackTrace) {        


### PR DESCRIPTION
# Why

We want to be sure, all error types received in the unhandled exception handler will be reported to Backtrace. This diff makes sure, that every time we get an error in the Android unhandled exception handler, it will be converted into a backtrace report and stored to be sent 

refs BT-1964

refs BT-779