### PR TITLE
Remove device name reference

### DIFF
--- a/Runtime/Model/Attributes/PiiAttributeProvider.cs
+++ b/Runtime/Model/Attributes/PiiAttributeProvider.cs
@@ -19,8 +19,6 @@ namespace Backtrace.Unity.Model.Attributes
             {
                 attributes["device.model"] = SystemInfo.deviceModel;
                 attributes["device.machine"] = SystemInfo.deviceModel;
-                // This is typically the "name" of the device as it appears on the networks.
-                attributes["device.name"] = SystemInfo.deviceName;
                 attributes["device.type"] = SystemInfo.deviceType.ToString();
             }
         }


### PR DESCRIPTION
# Why

https://docs.unity3d.com/ScriptReference/SystemInfo-deviceName.html

Based on this Unity API description it looks like, Unity will fallback to Bluetooth name on Android, which could cause unexpected problems on the client API - some applications don't need Bluetooth permission and we shouldn't require that. 

In addition to that, most of the time, this is the attribute that should be removed because of PII.  

Based on information above, I think we should remove it.


refs BT-2212 