### PR TITLE
Rename uname.sysname attribute for iOS

### DIFF
--- a/Runtime/Common/SystemHelper.cs
+++ b/Runtime/Common/SystemHelper.cs
@@ -72,7 +72,7 @@ namespace Backtrace.Unity.Common
                 case RuntimePlatform.Android:
                     return "Android";
                 case RuntimePlatform.IPhonePlayer:
-                    return "IOS";
+                    return "iOS";
                 case RuntimePlatform.LinuxEditor:
                 case RuntimePlatform.LinuxPlayer:
                     return "Linux";


### PR DESCRIPTION
# Why
We want to unify all our attributes. Because of this we want to rename uname.sysname attribute on iOS from "IOS" to "iOS" 

ref: BT-2764