### PR TITLE
Allow defining not supported variables

### DIFF
--- a/Runtime/Attributes.meta
+++ b/Runtime/Attributes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f354e77c1d37ece40ac522611a2406e4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Attributes/NotSupportedAttribute.cs
+++ b/Runtime/Attributes/NotSupportedAttribute.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Backtrace.Unity.Attributes
+{
+    [Obsolete("Not supported")]
+    public class NotSupportedAttribute : Attribute
+    {
+    }
+}

--- a/Runtime/Attributes/NotSupportedAttribute.cs.meta
+++ b/Runtime/Attributes/NotSupportedAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 502694db60fa0574c9a55a5c737572bf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Model/BacktraceConfiguration.cs
+++ b/Runtime/Model/BacktraceConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using Backtrace.Unity.Common;
+﻿using Backtrace.Unity.Attributes;
+using Backtrace.Unity.Common;
 using Backtrace.Unity.Model.Breadcrumbs;
 using Backtrace.Unity.Services;
 using Backtrace.Unity.Types;
@@ -125,7 +126,6 @@ namespace Backtrace.Unity.Model
         [Tooltip("Try to find game native crashes and send them on Game startup")]
         public bool SendUnhandledGameCrashesOnGameStartup = true;
 
-#if UNITY_ANDROID || UNITY_IOS || UNITY_STANDALONE_WIN || UNITY_GAMECORE_XBOXSERIES
 #if UNITY_ANDROID
         /// <summary>
         /// Capture native NDK Crashes.
@@ -136,47 +136,66 @@ namespace Backtrace.Unity.Model
         /// Capture native crashes.
         /// </summary>
         [Tooltip("Capture native Crashes")]
+#else
+        /// <summary>  
+        /// Capture native crashes.
+        /// </summary>
+        [NotSupported]
 #endif
-
         public bool CaptureNativeCrashes = true;
-#if !UNITY_GAMECORE_XBOXSERIES
+
         /// <summary>
         /// Handle ANR events - Application not responding
         /// </summary>
+#if UNITY_ANDROID || UNITY_IOS || UNITY_STANDALONE_WIN
         [Tooltip("Capture ANR events - Application not responding")]
-        public bool HandleANR = true;
+#else
+        [NotSupported]
 #endif
+        public bool HandleANR = true;
+
 
         /// <summary>
         /// Anr watchdog timeout in ms. Time needed to detect an ANR event
         /// </summary>
+#if UNITY_ANDROID || UNITY_IOS || UNITY_STANDALONE_WIN
+        [Tooltip("ANR watchdog timeout")]
+#else
+        [NotSupported]
+#endif
         public int AnrWatchdogTimeout = DefaultAnrWatchdogTimeout;
 
-#if UNITY_ANDROID || UNITY_IOS
         /// <summary>
         /// Send Out of memory exceptions to Backtrace. 
         /// </summary>
+#if UNITY_ANDROID || UNITY_IOS
         [Tooltip("Send Out of Memory exceptions to Backtrace")]
+#else
+        [NotSupported]
+#endif
         public bool OomReports = false;
 
-#if UNITY_2019_2_OR_NEWER
         /// <summary>
         /// Enable client side unwinding.
         /// </summary>
+#if UNITY_2019_2_OR_NEWER && (UNITY_ANDROID || UNITY_IOS)
         [Tooltip("Enable client-side unwinding.")]
+#else
+        [NotSupported]
+#endif
         public bool ClientSideUnwinding = false;
-#endif
 
-#endif
 
-#if UNITY_2019_2_OR_NEWER && UNITY_ANDROID
         /// <summary>
         /// Symbols upload token
         /// </summary>
+#if UNITY_2019_2_OR_NEWER && UNITY_ANDROID
         [Tooltip("Symbols upload token required to upload symbols to Backtrace")]
+#else
+        [NotSupported]
+#endif
         public string SymbolsUploadToken = string.Empty;
-#endif
-#endif
+
 
         /// <summary>
         /// Backtrace client deduplication strategy. 

--- a/Tests/Runtime/BacktraceClientTests.cs
+++ b/Tests/Runtime/BacktraceClientTests.cs
@@ -19,6 +19,22 @@ namespace Backtrace.Unity.Tests.Runtime
         }
 
         [UnityTest]
+        public IEnumerator TestClientConfigurationOptions_ValidConfigurationWithAllOptions_AllowsToUseNotSupportedOptions()
+        {
+            var clientConfiguration = GetValidClientConfiguration();
+            clientConfiguration.OomReports = false;
+            clientConfiguration.HandleANR = false;
+            clientConfiguration.AnrWatchdogTimeout = 0;
+            clientConfiguration.CaptureNativeCrashes = false;
+            clientConfiguration.ClientSideUnwinding = false;
+            clientConfiguration.SymbolsUploadToken = string.Empty;
+            BacktraceClient.Configuration = clientConfiguration;
+            BacktraceClient.Refresh();
+            Assert.IsTrue(BacktraceClient.Enabled);
+            yield return null;
+        }
+
+        [UnityTest]
         public IEnumerator TestClientCreation_ValidBacktraceConfiguration_ValidClientCreation()
         {
             var clientConfiguration = GetValidClientConfiguration();


### PR DESCRIPTION
# Why

The configuration object created by a user to create `BacktraceClient` requires properties available only in specific OSes. When the user needs to switch between different OS builds, most of the time it requires wrapping the initialization object with the #ifdef which is not a great user experience. 

The current change allows to define all properties in the backtrace configuration object. Not supported properties on specific OS will be marked as unsupported via NotSupported attribute. 

ref: BT-535