### PR TITLE
Extend breadcrumbs interface with new method that allows to define breadcrumb level

### DIFF
--- a/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbs.cs
+++ b/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbs.cs
@@ -69,14 +69,15 @@ namespace Backtrace.Unity.Model.Breadcrumbs
 
         public bool FromBacktrace(BacktraceReport report)
         {
+            const BreadcrumbLevel level = BreadcrumbLevel.System;
             var type = report.ExceptionTypeReport ? UnityEngineLogLevel.Error : UnityEngineLogLevel.Info;
-            if (!ShouldLog(type))
+            if (!ShouldLog(level, type))
             {
                 return false;
             }
             return AddBreadcrumbs(
                 report.Message,
-                BreadcrumbLevel.System,
+                level,
                 type,
                 null);
         }
@@ -137,24 +138,31 @@ namespace Backtrace.Unity.Model.Breadcrumbs
         }
         public bool Log(string message, LogType logType, IDictionary<string, string> attributes)
         {
-            var type = ConvertLogTypeToLogLevel(logType);
-            if (!ShouldLog(type))
-            {
-                return false;
-            }
-            return AddBreadcrumbs(message, BreadcrumbLevel.Manual, type, attributes);
+            return Log(message, BreadcrumbLevel.Manual, logType, attributes);
         }
+
+        public bool Log(string message, BreadcrumbLevel level, LogType logType, IDictionary<string, string> attributes)
+        {
+            var type = ConvertLogTypeToLogLevel(logType);
+            return AddBreadcrumbs(message, level, type, attributes);
+        }
+
         internal bool AddBreadcrumbs(string message, BreadcrumbLevel level, UnityEngineLogLevel type, IDictionary<string, string> attributes = null)
         {
-            if (!BreadcrumbsLevel.HasFlag((BacktraceBreadcrumbType)level))
+            if (!ShouldLog(level, type))
             {
                 return false;
             }
             return LogManager.Add(message, level, type, attributes);
         }
-        internal bool ShouldLog(UnityEngineLogLevel type)
+
+        internal bool ShouldLog(BreadcrumbLevel level, UnityEngineLogLevel type)
         {
-            if (!BreadcrumbsLevel.HasFlag(BacktraceBreadcrumbType.Manual))
+            return ShouldLog((BacktraceBreadcrumbType)level, type);
+        }
+        internal bool ShouldLog(BacktraceBreadcrumbType level, UnityEngineLogLevel type)
+        {
+            if (!BreadcrumbsLevel.HasFlag(level))
             {
                 return false;
             }

--- a/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbsEventHandler.cs
+++ b/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbsEventHandler.cs
@@ -139,7 +139,7 @@ namespace Backtrace.Unity.Model.Breadcrumbs
         private void Log(string message, LogType level, BreadcrumbLevel breadcrumbLevel, IDictionary<string, string> attributes = null)
         {
             var type = BacktraceBreadcrumbs.ConvertLogTypeToLogLevel(level);
-            if (!_breadcrumbs.ShouldLog(type))
+            if (!_breadcrumbs.ShouldLog(breadcrumbLevel, type))
             {
                 return;
             }

--- a/Runtime/Model/Breadcrumbs/IBacktraceBreadcrumbs.cs
+++ b/Runtime/Model/Breadcrumbs/IBacktraceBreadcrumbs.cs
@@ -11,6 +11,7 @@ namespace Backtrace.Unity.Model.Breadcrumbs
         [Obsolete("Please use EnableBreadcrumbs instead. This function will be removed in the future updates")]
         bool EnableBreadcrumbs(BacktraceBreadcrumbType level, UnityEngineLogLevel unityLogLevel);
         bool ClearBreadcrumbs();
+        bool Log(string message, BreadcrumbLevel level, LogType logType, IDictionary<string, string> attributes);
         bool Log(string message, LogType type, IDictionary<string, string> attributes);
         bool Log(string message, LogType type);
         bool Debug(string message);

--- a/Tests/Runtime/Breadcrumbs/BacktraceBreadcrumbsTypeTests.cs
+++ b/Tests/Runtime/Breadcrumbs/BacktraceBreadcrumbsTypeTests.cs
@@ -7,6 +7,36 @@ namespace Backtrace.Unity.Tests.Runtime.Breadcrumbs
 {
     public class BacktraceBreadcrumbsTypeTests
     {
+
+        [Test]
+        public void TestManualLogWithLogLevel_ShouldSuccessfullyAddLog_LogIsStored()
+        {
+            const string message = "message";
+            var inMemoryBreadcrumbStorage = new BacktraceInMemoryLogManager();
+            //anything else than Manual
+            BreadcrumbLevel breadcrumbLevel = BreadcrumbLevel.System;
+            UnityEngineLogLevel level = UnityEngineLogLevel.Debug | UnityEngineLogLevel.Error | UnityEngineLogLevel.Fatal | UnityEngineLogLevel.Info | UnityEngineLogLevel.Warning;
+            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage, BacktraceBreadcrumbType.System, level);
+            breadcrumbsManager.EnableBreadcrumbs();
+            var result = breadcrumbsManager.Log(message, breadcrumbLevel, LogType.Log, null);
+            Assert.IsTrue(result);
+        }
+
+
+        [Test]
+        public void TestManualLogWithLogLevel_ShouldDropUnwantedBreadcrumbLevel_ReturnFalse()
+        {
+            const string message = "message";
+            var inMemoryBreadcrumbStorage = new BacktraceInMemoryLogManager();
+            //anything else than Manual
+            BreadcrumbLevel breadcrumbLevel = BreadcrumbLevel.Configuration;
+            UnityEngineLogLevel level = UnityEngineLogLevel.Debug | UnityEngineLogLevel.Error | UnityEngineLogLevel.Fatal | UnityEngineLogLevel.Info | UnityEngineLogLevel.Warning;
+            var breadcrumbsManager = new BacktraceBreadcrumbs(inMemoryBreadcrumbStorage, BacktraceBreadcrumbType.User, level);
+            breadcrumbsManager.EnableBreadcrumbs();
+            var result = breadcrumbsManager.Log(message, breadcrumbLevel, LogType.Log, null);
+            Assert.IsFalse(result);
+
+        }
         [TestCase(LogType.Log)]
         [TestCase(LogType.Warning)]
         [TestCase(LogType.Assert)]


### PR DESCRIPTION
# Why

This diff allows to expose one more method via Breadcrumb interface that allows to define breadcrumb level.

refs BT-2749