### PR TITLE
Allow unity to finish capturing uncaught exception

### DIFF
--- a/Android/BacktraceAndroidBackgroundUnhandledExceptionHandler.java
+++ b/Android/BacktraceAndroidBackgroundUnhandledExceptionHandler.java
@@ -51,7 +51,6 @@ public class BacktraceAndroidBackgroundUnhandledExceptionHandler implements Thre
         String throwableType = throwable.getClass().getName();
         Log.d(LOG_TAG, "Detected unhandled background thread exception. Exception type: " + throwableType + ". Reporting to Backtrace");
         ReportThreadException(throwableType + " : " + throwable.getMessage(), stackTraceToString(throwable.getStackTrace()));
-        finish();
     }
 
     public void ReportThreadException(String message, String stackTrace) {        


### PR DESCRIPTION
# Why

This diff allows to wait until Unity layer captures unhandled java exception captured via `BacktraceAndroidBackgroundUnhandledExceptionHandler` 