### PR TITLE
Proguard support

### DIFF
--- a/Android/BacktraceAndroidBackgroundUnhandledExceptionHandler.java
+++ b/Android/BacktraceAndroidBackgroundUnhandledExceptionHandler.java
@@ -51,7 +51,6 @@ public class BacktraceAndroidBackgroundUnhandledExceptionHandler implements Thre
         String throwableType = throwable.getClass().getName();
         Log.d(LOG_TAG, "Detected unhandled background thread exception. Exception type: " + throwableType + ". Reporting to Backtrace");
         ReportThreadException(throwableType + " : " + throwable.getMessage(), stackTraceToString(throwable.getStackTrace()));
-        finish();
     }
 
     public void ReportThreadException(String message, String stackTrace) {        

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -69,6 +69,10 @@ namespace Backtrace.Unity
 #if UNITY_ANDROID
         private bool _useProguard = false;
 
+         /// <summary>
+        /// Allow to enable Proguard support for captured Exceptions.
+        /// </summary>
+        /// <param name="symbolicationId">Proguard map symbolication id</param>
         public void UseProguard(String symbolicationId) {
             _useProguard = true;
             AttributeProvider["symbolication_id"] = symbolicationId;

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -1002,7 +1002,7 @@ namespace Backtrace.Unity
             var message = backgroundExceptionMessage.Substring(0, splitIndex);
             var stackTrace = backgroundExceptionMessage.Substring(splitIndex);
             var report = new BacktraceReport(new BacktraceUnhandledException(message, stackTrace));
-             if (_useProguard) {
+            if (_useProguard) {
                 report.UseSymbolication("proguard");
             }
             

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -69,7 +69,7 @@ namespace Backtrace.Unity
 #if UNITY_ANDROID
         private bool _useProguard = false;
 
-         /// <summary>
+        /// <summary>
         /// Allow to enable Proguard support for captured Exceptions.
         /// </summary>
         /// <param name="symbolicationId">Proguard map symbolication id</param>

--- a/Runtime/Model/BacktraceData.cs
+++ b/Runtime/Model/BacktraceData.cs
@@ -83,6 +83,11 @@ namespace Backtrace.Unity.Model
         public string[] Classifier;
 
         /// <summary>
+        /// Symbolication method
+        /// </summary>
+        public String Symbolication;
+
+        /// <summary>
         /// Source code information.
         /// </summary>
         public BacktraceSourceCode SourceCode;
@@ -125,6 +130,7 @@ namespace Backtrace.Unity.Model
             Uuid = Report.Uuid;
             Timestamp = Report.Timestamp;
             Classifier = Report.ExceptionTypeReport ? new[] { Report.Classifier } : new string[0];
+            Symbolication = report.Symbolication;
 
             SetAttributes(clientAttributes, gameObjectDepth);
             SetThreadInformations();
@@ -152,6 +158,11 @@ namespace Backtrace.Unity.Model
             jObject.Add("attributes", Attributes.ToJson());
             jObject.Add("annotations", Annotation.ToJson());
             jObject.Add("threads", ThreadData.ToJson());
+            
+            if (!String.IsNullOrEmpty(Symbolication)) {
+                jObject.Add("symbolication", Symbolication);
+            }
+            
             if (SourceCode != null)
             {
                 jObject.Add("sourceCode", SourceCode.ToJson());

--- a/Runtime/Model/BacktraceReport.cs
+++ b/Runtime/Model/BacktraceReport.cs
@@ -72,6 +72,11 @@ namespace Backtrace.Unity.Model
         public List<BacktraceStackFrame> DiagnosticStack { get; set; }
 
         /// <summary>
+        /// Current report symbolication method
+        /// </summary>
+        public String Symbolication { get; set; }
+
+        /// <summary>
         /// Source code
         /// </summary>
         public BacktraceSourceCode SourceCode = null;
@@ -117,6 +122,14 @@ namespace Backtrace.Unity.Model
                 SetStacktraceInformation();
             }
             SetDefaultAttributes();
+        }
+
+        
+        /// <summary>
+        /// Sets report symbolication type
+        /// </summary>
+        public void UseSymbolication(String symbolication) {
+            Symbolication = symbolication;
         }
 
         private void SetDefaultAttributes()


### PR DESCRIPTION
# Why

This pull request adds support for Proguard to the `BacktraceClient`. By using our new proguard symbolication API our customers can set symbolication id for their proguard maps.


ref: BT-2975