### PR TITLE
Make sure we never check values outside _logSize queue

### DIFF
--- a/Runtime/Model/Breadcrumbs/Storage/BacktraceStorageLogManager.cs
+++ b/Runtime/Model/Breadcrumbs/Storage/BacktraceStorageLogManager.cs
@@ -290,7 +290,14 @@ namespace Backtrace.Unity.Model.Breadcrumbs.Storage
             int nextLineBytes = NewRow.Length;
             while (numberOfFreeBytes < expectedFreedBytes)
             {
-                numberOfFreeBytes += (_logSize.Dequeue() + nextLineBytes);
+                if (_logSize.TryDequeue(out long result))
+                {
+                    numberOfFreeBytes += (result + nextLineBytes);
+                }
+                else
+                {
+                    return numberOfFreeBytes;
+                }
             }
 
             return numberOfFreeBytes;

--- a/Runtime/Model/Breadcrumbs/Storage/BacktraceStorageLogManager.cs
+++ b/Runtime/Model/Breadcrumbs/Storage/BacktraceStorageLogManager.cs
@@ -290,14 +290,12 @@ namespace Backtrace.Unity.Model.Breadcrumbs.Storage
             int nextLineBytes = NewRow.Length;
             while (numberOfFreeBytes < expectedFreedBytes)
             {
-                if (_logSize.TryDequeue(out long result))
-                {
-                    numberOfFreeBytes += (result + nextLineBytes);
-                }
-                else
+                if (_logSize.Count == 0)
                 {
                     return numberOfFreeBytes;
                 }
+
+                numberOfFreeBytes += (_logSize.Dequeue() + nextLineBytes);
             }
 
             return numberOfFreeBytes;


### PR DESCRIPTION
# Why

One customer shared with us a potentially bad situation that happened in the BacktraceStorageLogManager implementation - it looks like we ran outside _logSize array. Normally it cannot happen, however, we want to be sure, that even if we have a bug, the code works correctly. 

This simple patch makes sure we don't run outside _logSize array