### PR TITLE
Unity unhandled exception proguard flow

### DIFF
--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -1146,8 +1146,14 @@ namespace Backtrace.Unity
                     Type = type
                 };
             }
+            var report = new BacktraceReport(exception);
+#if UNITY_ANDROID
+            if(exception.NativeStackTrace && _useProguard) {
+                report.UseSymbolication("proguard");
+            }
+#endif
 
-            SendUnhandledExceptionReport(new BacktraceReport(exception), invokeSkipApi);
+            SendUnhandledExceptionReport(report, invokeSkipApi);
         }
 
         /// <summary>

--- a/Runtime/Model/BacktraceUnhandledException.cs
+++ b/Runtime/Model/BacktraceUnhandledException.cs
@@ -48,6 +48,14 @@ namespace Backtrace.Unity.Model
         /// </summary>
         public readonly List<BacktraceStackFrame> StackFrames;
 
+        /// <summary>
+        /// Returns information if the stack trace is from the native environment (non-Unity)
+        /// </summary>
+        internal bool NativeStackTrace
+        {
+            get;
+            private set;
+        }
 
         public BacktraceUnhandledException(string message, string stacktrace) : base(message)
         {
@@ -172,6 +180,8 @@ namespace Backtrace.Unity.Model
                     FunctionName = frameString
                 };
             }
+
+            NativeStackTrace = true;
             // add length of the '('
             methodStartIndex += 1;
             var methodArguments = frameString.Substring(methodStartIndex, methodNameEndIndex - methodStartIndex);
@@ -250,7 +260,8 @@ namespace Backtrace.Unity.Model
                 {
                     stackFrame.Library = stackFrame.FunctionName.Substring(0, libraryNameSeparator).Trim();
                     stackFrame.FunctionName = stackFrame.FunctionName.Substring(++libraryNameSeparator).Trim();
-                } else
+                }
+                else
                 {
                     stackFrame.Library = "native";
                 }

--- a/Tests/Runtime/BacktraceStackTraceTests.cs
+++ b/Tests/Runtime/BacktraceStackTraceTests.cs
@@ -345,6 +345,23 @@ namespace Backtrace.Unity.Tests.Runtime
             }
         }
 
+        [Test]
+        public void TestNativeStackTraceDetection_AndroidExceptionShouldSetFlag_NativeStackTraceIsSet()
+        {
+            var stackTrace = ConvertStackTraceToString(_anrStackTrace);
+            var exception = new BacktraceUnhandledException(string.Empty, stackTrace);
+            Assert.IsTrue(exception.NativeStackTrace);
+        }
+
+
+        [Test]
+        public void TestNativeStackTraceDetection_UnityExceptionShouldNotSetFlag_NativeStackTraceIsNotSet()
+        {
+            var stackTrace = ConvertStackTraceToString(_simpleStack);
+            var exception = new BacktraceUnhandledException(string.Empty, stackTrace);
+            Assert.IsFalse(exception.NativeStackTrace);
+        }
+
 
         [Test]
         public void TestStackTraceCreation_AndroidMixModeCallStack_ValidStackTraceObject()


### PR DESCRIPTION
# Why

Unity uncaught exception handler can also capture unhandled exceptions thrown by the managed Java code. The following code in the java managed layer can be captured by Unity exception handler:

```
  throw new RuntimeException("Unity-test: Uncaught JVM exception");
```

In this flow we didn't apply proguard symbolication. This patch makes sure the symbolication flow is applied in the unity uncaught exception handler. 

ref: BT-2993