### PR TITLE
iOS native bindings update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Backtrace Unity Release Notes
 
+## Version 3.9.0
+
+Bugfixes
+- Allow unity to finish capturing uncaught exception generated on the Android native layer (#215).
+
+Improvements
+- Proguard Support. Added support for native managed exceptions when ProGuard obfuscation is in use (#216).
+- Updated native NDK libraries to the latest version of the backtrace-android library (#217).
+- Added support for a new crash flow when the crash handler executable cannot be extracted on Android. The `useLegacyPackaging` is no longer required. (#218).
+
 ## Version 3.8.7
 
 Bugfixes

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -24,7 +24,7 @@ namespace Backtrace.Unity
     /// </summary>
     public class BacktraceClient : MonoBehaviour, IBacktraceClient
     {
-        public const string VERSION = "3.8.7";
+        public const string VERSION = "3.9.0";
         internal const string DefaultBacktraceGameObjectName = "BacktraceClient";
         public BacktraceConfiguration Configuration;
 

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -1146,8 +1146,14 @@ namespace Backtrace.Unity
                     Type = type
                 };
             }
+            var report = new BacktraceReport(exception);
+#if UNITY_ANDROID
+            if(exception.NativeStackTrace && _useProguard) {
+                report.UseSymbolication("proguard");
+            }
+#endif
 
-            SendUnhandledExceptionReport(new BacktraceReport(exception), invokeSkipApi);
+            SendUnhandledExceptionReport(report, invokeSkipApi);
         }
 
         /// <summary>

--- a/Runtime/Model/BacktraceUnhandledException.cs
+++ b/Runtime/Model/BacktraceUnhandledException.cs
@@ -48,6 +48,14 @@ namespace Backtrace.Unity.Model
         /// </summary>
         public readonly List<BacktraceStackFrame> StackFrames;
 
+        /// <summary>
+        /// Returns information if the stack trace is from the native environment (non-Unity)
+        /// </summary>
+        internal bool NativeStackTrace
+        {
+            get;
+            private set;
+        }
 
         public BacktraceUnhandledException(string message, string stacktrace) : base(message)
         {
@@ -172,6 +180,8 @@ namespace Backtrace.Unity.Model
                     FunctionName = frameString
                 };
             }
+
+            NativeStackTrace = true;
             // add length of the '('
             methodStartIndex += 1;
             var methodArguments = frameString.Substring(methodStartIndex, methodNameEndIndex - methodStartIndex);
@@ -250,7 +260,8 @@ namespace Backtrace.Unity.Model
                 {
                     stackFrame.Library = stackFrame.FunctionName.Substring(0, libraryNameSeparator).Trim();
                     stackFrame.FunctionName = stackFrame.FunctionName.Substring(++libraryNameSeparator).Trim();
-                } else
+                }
+                else
                 {
                     stackFrame.Library = "native";
                 }

--- a/Runtime/Model/Breadcrumbs/Storage/BacktraceStorageLogManager.cs
+++ b/Runtime/Model/Breadcrumbs/Storage/BacktraceStorageLogManager.cs
@@ -290,7 +290,14 @@ namespace Backtrace.Unity.Model.Breadcrumbs.Storage
             int nextLineBytes = NewRow.Length;
             while (numberOfFreeBytes < expectedFreedBytes)
             {
-                numberOfFreeBytes += (_logSize.Dequeue() + nextLineBytes);
+                if (_logSize.TryDequeue(out long result))
+                {
+                    numberOfFreeBytes += (result + nextLineBytes);
+                }
+                else
+                {
+                    return numberOfFreeBytes;
+                }
             }
 
             return numberOfFreeBytes;

--- a/Tests/Runtime/BacktraceStackTraceTests.cs
+++ b/Tests/Runtime/BacktraceStackTraceTests.cs
@@ -345,6 +345,23 @@ namespace Backtrace.Unity.Tests.Runtime
             }
         }
 
+        [Test]
+        public void TestNativeStackTraceDetection_AndroidExceptionShouldSetFlag_NativeStackTraceIsSet()
+        {
+            var stackTrace = ConvertStackTraceToString(_anrStackTrace);
+            var exception = new BacktraceUnhandledException(string.Empty, stackTrace);
+            Assert.IsTrue(exception.NativeStackTrace);
+        }
+
+
+        [Test]
+        public void TestNativeStackTraceDetection_UnityExceptionShouldNotSetFlag_NativeStackTraceIsNotSet()
+        {
+            var stackTrace = ConvertStackTraceToString(_simpleStack);
+            var exception = new BacktraceUnhandledException(string.Empty, stackTrace);
+            Assert.IsFalse(exception.NativeStackTrace);
+        }
+
 
         [Test]
         public void TestStackTraceCreation_AndroidMixModeCallStack_ValidStackTraceObject()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "io.backtrace.unity",
   "displayName": "Backtrace",
-  "version": "3.8.7",
+  "version": "3.9.0",
   "unity": "2017.1",
   "description": "Backtrace's integration with Unity games allows customers to capture and report handled and unhandled Unity exceptions to their Backtrace instance, instantly offering the ability to prioritize and debug software errors.",
   "keywords": [


### PR DESCRIPTION
# Why

This pull request updates our iOS native binaries. This change includes:
- PlCrashReporter update from 1.7.2 to the latest one - 1.11.2.
- Storing client attributes in the PlCrashReporter crashData object. 
- Renaming process.vm.* attributes to vm.* 
- Include detailed error message in iOS crash report