### PR TITLE
Fix Unity console errors caused by corrupt meta

### DIFF
--- a/Android/BacktraceCrashHandler.java.meta
+++ b/Android/BacktraceCrashHandler.java.meta
@@ -22,7 +22,7 @@ PluginImporter:
       enabled: 0
       settings: {}
   - first:
-
+      Editor: Editor
     second:
       enabled: 0
       settings:


### PR DESCRIPTION
These errors are being logged to the Unity console because of a broken meta file:
```
Tried to get mapping information from scalar node
Assertion failed on expression: 'IsMapping()'
```
