### PR TITLE
Internet availability checks

### DIFF
--- a/Runtime/BacktraceDatabase.cs
+++ b/Runtime/BacktraceDatabase.cs
@@ -236,7 +236,7 @@ namespace Backtrace.Unity
             }
             if (_breadcrumbs != null)
             {
-                _breadcrumbs.Update();
+                _breadcrumbs.Update(Time.unscaledTime);
             }
             LastFrameTime = Time.unscaledTime;
             if (!DatabaseSettings.AutoSendMode)

--- a/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbs.cs
+++ b/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbs.cs
@@ -191,9 +191,9 @@ namespace Backtrace.Unity.Model.Breadcrumbs
             return LogManager.BreadcrumbId();
         }
 
-        public void Update()
+        public void Update(float time)
         {
-            EventHandler.Update();
+            EventHandler.Update(time);
         }
 
         public static bool CanStoreBreadcrumbs(UnityEngineLogLevel logLevel, BacktraceBreadcrumbType backtraceBreadcrumbsLevel)

--- a/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbsEventHandler.cs
+++ b/Runtime/Model/Breadcrumbs/BacktraceBreadcrumbsEventHandler.cs
@@ -13,6 +13,10 @@ namespace Backtrace.Unity.Model.Breadcrumbs
         private BacktraceBreadcrumbType _registeredLevel;
         private NetworkReachability _networkStatus = NetworkReachability.NotReachable;
         private Thread _thread;
+        private float _lastUpdateTime = 0;
+
+        // time in seconds between internet availability checks
+        private float INTERNET_AVAILABILITY_CHECK_INTERVAL_SEC = 30;
         public BacktraceBreadcrumbsEventHandler(BacktraceBreadcrumbs breadcrumbs)
         {
             _thread = Thread.CurrentThread;
@@ -151,8 +155,13 @@ namespace Backtrace.Unity.Model.Breadcrumbs
             Log(string.Format("Network:{0}", status), LogType.Log, BreadcrumbLevel.System);
         }
 
-        internal void Update()
+        internal void Update(float time)
         {
+            if (time - _lastUpdateTime < INTERNET_AVAILABILITY_CHECK_INTERVAL_SEC && _lastUpdateTime != 0)
+            {
+                return;
+            }
+            _lastUpdateTime = time;
             if (_registeredLevel.HasFlag(BacktraceBreadcrumbType.System) && Application.internetReachability != _networkStatus)
             {
                 LogNewNetworkStatus(Application.internetReachability);

--- a/Runtime/Model/Breadcrumbs/IBacktraceBreadcrumbs.cs
+++ b/Runtime/Model/Breadcrumbs/IBacktraceBreadcrumbs.cs
@@ -29,7 +29,7 @@ namespace Backtrace.Unity.Model.Breadcrumbs
         string GetBreadcrumbLogPath();
         double BreadcrumbId();
         void UnregisterEvents();
-        void Update();
+        void Update(float time);
         string Archive();
     }
 }


### PR DESCRIPTION
# Why

We're checking internet connection availability too often. We can check it every 30 seconds instead. To remove additional checks and some time-consuming code, the internet connection availability will be checked every 30 seconds now.

ref: BT-3079