### PR TITLE
Expose BacktraceMetrics.SessionId and BacktraceClient.AttributeProvider

### DIFF
--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -50,7 +50,7 @@ namespace Backtrace.Unity
         /// <summary>
         /// Client attribute provider
         /// </summary>
-        internal AttributeProvider AttributeProvider
+        public AttributeProvider AttributeProvider
         {
             get
             {

--- a/Runtime/Interfaces/IBacktraceMetrics.cs
+++ b/Runtime/Interfaces/IBacktraceMetrics.cs
@@ -1,4 +1,5 @@
-﻿using Backtrace.Unity.Model.Attributes;
+﻿using System;
+using Backtrace.Unity.Model.Attributes;
 using Backtrace.Unity.Model.Metrics;
 using System.Collections.Generic;
 
@@ -15,6 +16,8 @@ namespace Backtrace.Unity.Interfaces
         /// Please refer to the <see href="https://support.backtrace.io">online documentation</see>.
         /// </summary>
         //LinkedList<UniqueEvent> UniqueEvents { get; }
+
+        Guid SessionId { get; }
 
         /// <summary>
         /// Maximum number of summed events in store. If number of events in store hit the limit

--- a/Runtime/Services/BacktraceMetrics.cs
+++ b/Runtime/Services/BacktraceMetrics.cs
@@ -16,7 +16,7 @@ namespace Backtrace.Unity.Services
         /// <summary>
         /// Session Id
         /// </summary>
-        public readonly Guid SessionId = Guid.NewGuid();
+        public Guid SessionId { get; } = Guid.NewGuid();
 
         /// <summary>
         /// Default submission URL


### PR DESCRIPTION
This is useful to allow SessionId and other attributes (e.g. 'guid') to be written to 'dying memory' on platforms that support it (e.g. Switch, PlayStation), which the Backtrace server is then able to parse on importing from platform crash reporting services, and set on the imported errors. It can then be correlated with other errors from the same session.