### PR TITLE
Expose BacktraceClient.SetAttribute

### DIFF
--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -186,6 +186,11 @@ namespace Backtrace.Unity
             }
         }
 
+        public void SetAttribute(string key, string value)
+        {
+            this[key] = value;
+        }
+
         /// <summary>
         /// Number of client attributes
         /// </summary>


### PR DESCRIPTION
This is useful to set single attributes without discarding other existing ones, as SetAttributes does. It's useful to set attributes before the BeforeSend callback is called, since then they'll get saved out to be sent with native crashes, where this callback won't get called.