### PR TITLE
Set system name attribute properly for PS5, and disambiguate Xbox types

### DIFF
--- a/Runtime/Common/SystemHelper.cs
+++ b/Runtime/Common/SystemHelper.cs
@@ -83,6 +83,8 @@ namespace Backtrace.Unity.Common
                     return "ps3";
                 case RuntimePlatform.PS4:
                     return "ps4";
+                case RuntimePlatform.PS5:
+                    return "ps5";
                 case RuntimePlatform.TizenPlayer:
                 case RuntimePlatform.SamsungTVPlayer:
                     return "Samsung TV";
@@ -101,8 +103,12 @@ namespace Backtrace.Unity.Common
                 case RuntimePlatform.WSAPlayerX86:
                     return "Windows";
                 case RuntimePlatform.XBOX360:
+                    return "Xbox 360";
                 case RuntimePlatform.XboxOne:
-                    return "Xbox";
+                case RuntimePlatform.GameCoreXboxOne:
+                    return "Xbox One";
+                case RuntimePlatform.GameCoreXboxSeries:
+                    return "Xbox Series";
                 default:
                     return Application.platform.ToString();
             }


### PR DESCRIPTION
PS5 has been renamed to lowercase 'ps5' instead of the default uppercase 'PS5'. The PS5 datasource also uses lowercase 'ps5', and this now matches the casing of 'ps4', so this change makes things more consistent. We've been using this on two projects in production and it makes for a cleaner dashboard.

For the Xbox types, it's very useful to disambiguate between the generations (as is done for PlayStation and Switch). On our previous project we had to use submission actions to rewrite uname.sysname based on other attributes, but for the current project we've been using this change and it works well. It's a bit of a matter of opinion how these names should be formatted, but this does match the casing and spacing of e.g. SamsungTVPlayer above.