### PR TITLE
Handle missing Backtrace/Crashpad DLLs gracefully

### DIFF
--- a/Runtime/Native/Windows/NativeClient.cs
+++ b/Runtime/Native/Windows/NativeClient.cs
@@ -108,6 +108,13 @@ namespace Backtrace.Unity.Runtime.Native.Windows
                 return;
             }
 
+            var backtraceCrashpadHandlerPath = GetDefaultPathToBacktraceCrashpadHandler(pluginDirectoryPath);
+            if (string.IsNullOrEmpty(backtraceCrashpadHandlerPath) || !File.Exists(backtraceCrashpadHandlerPath))
+            {
+                Debug.LogWarning("Backtrace native integration status: Cannot find path to Backtrace Crashpad handler.");
+                return;
+            }
+
             var databasePath = _configuration.CrashpadDatabasePath;
             if (string.IsNullOrEmpty(databasePath) || !Directory.Exists(_configuration.GetFullDatabasePath()))
             {
@@ -122,12 +129,19 @@ namespace Backtrace.Unity.Runtime.Native.Windows
                 Directory.CreateDirectory(databasePath);
             }
 
-            CaptureNativeCrashes = Initialize(
-                minidumpUrl,
-                databasePath,
-                crashpadHandlerPath,
-                attachments.ToArray(),
-                attachments.Count());
+            try
+            {
+                CaptureNativeCrashes = Initialize(
+                    minidumpUrl,
+                    databasePath,
+                    crashpadHandlerPath,
+                    attachments.ToArray(),
+                    attachments.Count() );
+            }
+            catch ( DllNotFoundException )
+            {
+                Debug.LogWarning("Backtrace native integration status: Can't load Backtrace DLL");
+            }
 
             if (!CaptureNativeCrashes)
             {
@@ -328,8 +342,16 @@ namespace Backtrace.Unity.Runtime.Native.Windows
             const string supportedArchitecture = "x86_64";
             var architectureDirectory = Path.Combine(pluginDirectoryPath, supportedArchitecture);
             return Path.Combine(architectureDirectory, crashpadHandlerName);
-
         }
+
+        private string GetDefaultPathToBacktraceCrashpadHandler(string pluginDirectoryPath)
+        {
+            const string crashpadHandlerName = "BacktraceCrashpadWindows.dll";
+            const string supportedArchitecture = "x86_64";
+            var architectureDirectory = Path.Combine(pluginDirectoryPath, supportedArchitecture);
+            return Path.Combine(architectureDirectory, crashpadHandlerName);
+        }
+
         /// <summary>
         /// Clean scoped attributes
         /// </summary>

--- a/Runtime/Native/Windows/NativeClient.cs
+++ b/Runtime/Native/Windows/NativeClient.cs
@@ -136,11 +136,12 @@ namespace Backtrace.Unity.Runtime.Native.Windows
                     databasePath,
                     crashpadHandlerPath,
                     attachments.ToArray(),
-                    attachments.Count() );
+                    attachments.Count());
             }
-            catch ( DllNotFoundException )
+            catch (DllNotFoundException)
             {
                 Debug.LogWarning("Backtrace native integration status: Can't load Backtrace DLL");
+                return;
             }
 
             if (!CaptureNativeCrashes)
@@ -269,7 +270,7 @@ namespace Backtrace.Unity.Runtime.Native.Windows
                 Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), tempDirectory),
                 Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), tempDirectory)
             };
-              
+
             List<string> nativeCrashesDirs = new List<string>();
             foreach (string direcotry in crashDirectories)
             {


### PR DESCRIPTION
Log a warning instead of allowing an unhandled exception to escape, if the Backtrace/Crashpad DLLs can't be found, or loaded.

This can happen if e.g. the system doesn't have the version of the VC runtime installed which is required to use these DLLs.