### PR TITLE
Fix error type attribute being set to hang for next error after a hang

### DIFF
--- a/Runtime/Native/Windows/NativeClient.cs
+++ b/Runtime/Native/Windows/NativeClient.cs
@@ -201,7 +201,7 @@ namespace Backtrace.Unity.Runtime.Native.Windows
 
                                 NativeReport(AnrMessage, true);
                                 // update error.type attribute in case when crash happen
-                                AddNativeAttribute(ErrorTypeAttribute, HangType);
+                                AddNativeAttribute(ErrorTypeAttribute, CrashType);
                             }
                         }
                         else


### PR DESCRIPTION
Minor change: after sending a Windows ANR hang report, make sure the next native crash isn't also treated as a hang.

I've not been able to verify that this works, but it certainly looks right and matches the intent of the comment above it! I think this was just a typo.