### PR TITLE
Expose Session Id via Backtrace Metrics

### DIFF
--- a/Runtime/Interfaces/IBacktraceMetrics.cs
+++ b/Runtime/Interfaces/IBacktraceMetrics.cs
@@ -1,5 +1,6 @@
 ﻿using Backtrace.Unity.Model.Attributes;
 using Backtrace.Unity.Model.Metrics;
+using System;
 using System.Collections.Generic;
 
 namespace Backtrace.Unity.Interfaces
@@ -21,6 +22,11 @@ namespace Backtrace.Unity.Interfaces
         /// BacktraceMetrics instance will send data to Backtrace.
         /// </summary>
         uint MaximumSummedEvents { get; set; }
+
+        /// <summary>
+        /// Current session Id
+        /// </summary>
+        Guid SessionId { get; }
 
         /// <summary>
         /// Maximum number of unique events in store. If number of events in store hit the limit

--- a/Runtime/Services/BacktraceMetrics.cs
+++ b/Runtime/Services/BacktraceMetrics.cs
@@ -16,7 +16,7 @@ namespace Backtrace.Unity.Services
         /// <summary>
         /// Session Id
         /// </summary>
-        public readonly Guid SessionId = Guid.NewGuid();
+        public readonly Guid SessionId { get; } = Guid.NewGuid();
 
         /// <summary>
         /// Default submission URL

--- a/Runtime/Services/BacktraceMetrics.cs
+++ b/Runtime/Services/BacktraceMetrics.cs
@@ -16,7 +16,7 @@ namespace Backtrace.Unity.Services
         /// <summary>
         /// Session Id
         /// </summary>
-        public readonly Guid SessionId { get; } = Guid.NewGuid();
+        public Guid SessionId { get; } = Guid.NewGuid();
 
         /// <summary>
         /// Default submission URL


### PR DESCRIPTION
# Why

This is the follow-up pull request that should fix the problem shown in the pull request: https://github.com/backtrace-labs/backtrace-unity/pull/232

