### PR TITLE
Change documentation url to docs.saucelabs.com

### DIFF
--- a/Runtime/Interfaces/IBacktraceMetrics.cs
+++ b/Runtime/Interfaces/IBacktraceMetrics.cs
@@ -12,7 +12,7 @@ namespace Backtrace.Unity.Interfaces
         /// and custom unique events can be added. Typical values to add are UserID, SteamID and other attributes that uniquely 
         /// identify an user. This list is persistent, meaning that events will not be removed upon Send() (like for summed events).
         /// For non-standard unique events, server side configuration needs to be done. 
-        /// Please refer to the <see href="https://support.backtrace.io">online documentation</see>.
+        /// Please refer to the <see href="https://docs.saucelabs.com/error-reporting/platform-integrations/unity/metrics/">online documentation</see>.
         /// </summary>
         //LinkedList<UniqueEvent> UniqueEvents { get; }
 
@@ -49,14 +49,14 @@ namespace Backtrace.Unity.Interfaces
         /// Adds a summed event to the outgoing queue.
         /// </summary>
         /// See <see cref="BacktraceClient.Metrics.Send(string, IDictionary)"/>.
-        /// <param name="metricGroupName">The name of the metric group to be incremented. This metric group must be configured on server side as well, please refer to the <see href = "https://support.backtrace.io" > online documentation</see>.</param>
+        /// <param name="metricGroupName">The name of the metric group to be incremented. This metric group must be configured on server side as well, please refer to the <see href = "https://docs.saucelabs.com/error-reporting/platform-integrations/unity/metrics/" > online documentation</see>.</param>
         /// <returns>true if added successfully, otherwise false.</returns>
         bool AddSummedEvent(string metricsGroupName);
 
         /// <summary>
         /// Adds a summed event to the outgoing queue.
         /// </summary>
-        /// <param name="metricGroupName">The name of the metric group to be incremented. This metric group must be configured on server side as well, please refer to the <see href = "https://support.backtrace.io" > online documentation</see>.</param>
+        /// <param name="metricGroupName">The name of the metric group to be incremented. This metric group must be configured on server side as well, please refer to the <see href = "https://docs.saucelabs.com/error-reporting/platform-integrations/unity/metrics/" > online documentation</see>.</param>
         /// <param name="attributes">Custom attributes to add. Will be merged with the default attributes, with attribute values provided here overriding any defaults.</param>
         /// <returns>true if added successfully, otherwise false.</returns>
         bool AddSummedEvent(string metricsGroupName, IDictionary<string, string> attributes);

--- a/Runtime/Services/BacktraceApi.cs
+++ b/Runtime/Services/BacktraceApi.cs
@@ -259,7 +259,7 @@ namespace Backtrace.Unity.Services
             Debug.LogWarning(string.Format("{0}{1}", string.Format("[Backtrace]::Reponse code: {0}, Response text: {1}",
                     request.responseCode,
                     request.error),
-                "\n Please check provided url to Backtrace service or learn more from our integration guide: https://support.backtrace.io/hc/en-us/articles/360040515991-Unity-Integration-Guide"));
+                "\n Please check provided url to Backtrace service or learn more from our integration guide: https://docs.saucelabs.com/error-reporting/platform-integrations/unity/setup/"));
         }
 
         //private string GetParametrizedQuery(string serverUrl, IDictionary<string, string> queryAttributes)


### PR DESCRIPTION
# Why

This pull request changes the documentation URL to docs.saucelabs.com

ref: BT-5445