### PR TITLE
Feature/set attribute

### DIFF
--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -142,11 +142,7 @@ namespace Backtrace.Unity
             }
             set
             {
-                AttributeProvider[index] = value;
-                if (_nativeClient != null)
-                {
-                    _nativeClient.SetAttribute(index, value);
-                }
+                SetAttribute(index, value);
             }
         }
 
@@ -171,6 +167,20 @@ namespace Backtrace.Unity
         }
 
         /// <summary>
+        /// Set a client attribute that will be included in every report
+        /// </summary>
+        /// <param name="key">Attribute name</param>
+        /// <param name="value">Attribute value</param>
+        public void SetAttribute(string key, string value) 
+        {
+            AttributeProvider[key] = value;
+            if (_nativeClient != null)
+            {
+                _nativeClient.SetAttribute(key, value);
+            }
+        }
+
+        /// <summary>
         /// Set client attributes that will be included in every report
         /// </summary>
         /// <param name="attributes">attributes dictionary</param>
@@ -182,7 +192,7 @@ namespace Backtrace.Unity
             }
             foreach (var attribute in attributes)
             {
-                this[attribute.Key] = attribute.Value;
+                SetAttribute(attribute.Key, attribute.Value);
             }
         }
 

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -171,13 +171,20 @@ namespace Backtrace.Unity
         /// </summary>
         /// <param name="key">Attribute name</param>
         /// <param name="value">Attribute value</param>
-        public void SetAttribute(string key, string value) 
+        /// <returns>True, if the value was added. Otherwise false.</returns>
+        public bool SetAttribute(string key, string value) 
         {
+            if (string.IsNullOrEmpty(key)) 
+            {
+                return false;
+            }
+            
             AttributeProvider[key] = value;
             if (_nativeClient != null)
             {
                 _nativeClient.SetAttribute(key, value);
             }
+            return true;
         }
 
         /// <summary>

--- a/Tests/Runtime/BacktraceAttributeTests.cs
+++ b/Tests/Runtime/BacktraceAttributeTests.cs
@@ -68,6 +68,27 @@ namespace Backtrace.Unity.Tests.Runtime
             yield return null;
         }
 
+        [UnityTest]
+        public IEnumerator TesClientAttributeMethod_BacktraceDataShouldIncludeClientAttribute_ClientAttributeAreAvailableInDiagnosticData()
+        {
+            var key = "attribute-key";
+            var value = "attribute-value";
+            BacktraceClient.SetAttribute(key, value);
+
+            BacktraceData data = null;
+            BacktraceClient.BeforeSend = (BacktraceData reportData) =>
+            {
+                data = reportData;
+                return null;
+            };
+            BacktraceClient.Send(new Exception("foo"));
+            yield return WaitForFrame.Wait();
+
+            Assert.IsNotNull(data);
+            Assert.AreEqual(data.Attributes.Attributes[key], value);
+            yield return null;
+        }
+
 
         [UnityTest]
         public IEnumerator TesClientAttributesMethod_BacktraceDataShouldIncludeClientAttributes_ClientAttributesAreAvailableInDiagnosticData()

--- a/Tests/Runtime/BacktraceAttributeTests.cs
+++ b/Tests/Runtime/BacktraceAttributeTests.cs
@@ -89,6 +89,20 @@ namespace Backtrace.Unity.Tests.Runtime
             yield return null;
         }
 
+        [UnityTest]
+        public IEnumerator TesClientAttributeMethod_ShouldNotAcceptNullableKey_AttributeIsNotAvailable()
+        {
+            Assert.IsFalse(BacktraceClient.SetAttribute(null, "attribute-value"));
+            yield return null;
+        }
+
+        [UnityTest]
+        public IEnumerator TesClientAttributeMethod_ShouldNotAcceptEmptyStringKey_AttributeIsNotAvailable()
+        {
+            Assert.IsFalse(BacktraceClient.SetAttribute(string.Empty, "attribute-value"));
+            yield return null;
+        }
+
 
         [UnityTest]
         public IEnumerator TesClientAttributesMethod_BacktraceDataShouldIncludeClientAttributes_ClientAttributesAreAvailableInDiagnosticData()


### PR DESCRIPTION
# Why

Backtrace Unity plugin has `[]` operator to set a key-value pair that represents an attribute. However, our users don't know about it, that is why we are preparing another option to set a key-value pair in the client. 

The `SetAttributes` method was also extended. Now every time, when attributes are set, they're also added to the native layer.