### PR TITLE
Release 3.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Improvements
 - Exposed an option to get an application.session id via `BacktraceMetrics` (#238).
 - Backtrace client now allows to set a key-value pair via `SetAttribute` method (#240).
-- `SetAttributes` method now will set attributes in the managed C# layer and in the native layer (#240).
+- The `SetAttributes` method will now set attributes in the managed C# layer and the native layer (#240).
 
 Bugfixes
 - Correct links to the docs (#239).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Backtrace Unity Release Notes
 
+## Version 3.12.0
+
+Improvements
+- Exposed an option to get an application.session id via `BacktraceMetrics` (#238).
+- Backtrace client now allows to set a key-value pair via `SetAttribute` method (#240).
+- `SetAttributes` method now will set attributes in the managed C# layer and in the native layer (#240).
+
+Bugfixes
+- Correct links to the docs (#239).
+- Fixed a problem where the game on Windows will crash in the release mode, due to lack of Backtrace native libraries (#236).
+- Fixed an `error.type` attribute value during handling ANR on Windows (#237).
+- Set correct `uname.sysname` for PS5 and Xbox.
+
+
 ## Version 3.11.0
 
 Improvements

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -24,7 +24,7 @@ namespace Backtrace.Unity
     /// </summary>
     public class BacktraceClient : MonoBehaviour, IBacktraceClient
     {
-        public const string VERSION = "3.11.0";
+        public const string VERSION = "3.12.0";
         internal const string DefaultBacktraceGameObjectName = "BacktraceClient";
         public BacktraceConfiguration Configuration;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "io.backtrace.unity",
   "displayName": "Backtrace",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "unity": "2017.1",
   "description": "Backtrace's integration with Unity games allows customers to capture and report handled and unhandled Unity exceptions to their Backtrace instance, instantly offering the ability to prioritize and debug software errors.",
   "keywords": [


### PR DESCRIPTION
## Version 3.12.0

Improvements
- Exposed an option to get an application.session id via `BacktraceMetrics` (#238).
- Backtrace client now allows to set a key-value pair via `SetAttribute` method (#240).
The `SetAttributes` method will now set attributes in the managed C# layer and the native layer (#240).

Bugfixes
- Correct links to the docs (#239).
- Fixed a problem where the game on Windows will crash in the release mode, due to lack of Backtrace native libraries (#236).
- Fixed an `error.type` attribute value during handling ANR on Windows (#237).
- Set correct `uname.sysname` for PS5 and Xbox.
