### PR TITLE
Remove env variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 Improvements
 - Exposed an option to get an application.session id via `BacktraceMetrics` (#238).
 - Backtrace client now allows to set a key-value pair via `SetAttribute` method (#240).
-- `SetAttributes` method now will set attributes in the managed C# layer and in the native layer (#240).
+- The `SetAttributes` method will now set attributes in the managed C# layer and the native layer (#240).
 
 Bugfixes
 - Correct links to the docs (#239).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Backtrace Unity Release Notes
 
+## Version 3.12.0
+
+Improvements
+- Exposed an option to get an application.session id via `BacktraceMetrics` (#238).
+- Backtrace client now allows to set a key-value pair via `SetAttribute` method (#240).
+- `SetAttributes` method now will set attributes in the managed C# layer and in the native layer (#240).
+
+Bugfixes
+- Correct links to the docs (#239).
+- Fixed a problem where the game on Windows will crash in the release mode, due to lack of Backtrace native libraries (#236).
+- Fixed an `error.type` attribute value during handling ANR on Windows (#237).
+- Set correct `uname.sysname` for PS5 and Xbox.
+
+
 ## Version 3.11.0
 
 Improvements

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -724,6 +724,7 @@ namespace Backtrace.Unity
 
         private void OnDestroy()
         {
+            Debug.LogWarning($"Backtrace: On Destroy");
             Enabled = false;
             if (_breadcrumbs != null)
             {
@@ -835,6 +836,7 @@ namespace Backtrace.Unity
             }
             if (!Enabled)
             {
+                Debug.LogWarning($"Backtrace: Cannot send report - Backtrace client is disabled.");
                 return;
             }
             StartCoroutine(CollectDataAndSend(report, sendCallback));
@@ -1129,6 +1131,7 @@ namespace Backtrace.Unity
         {
             if (!Enabled)
             {
+                Debug.LogWarning($"Backtrace: Backtrace integration is disabled");
                 return;
             }
             var unityMessage = new BacktraceUnityMessage(message, stackTrace, type);
@@ -1136,6 +1139,7 @@ namespace Backtrace.Unity
 
             if (!Configuration.HandleUnhandledExceptions)
             {
+                Debug.LogWarning($"Backtrace: HandleUnhandledExceptions is false");
                 return;
             }
             if (string.IsNullOrEmpty(message) || (type != LogType.Error && type != LogType.Exception))

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -24,7 +24,7 @@ namespace Backtrace.Unity
     /// </summary>
     public class BacktraceClient : MonoBehaviour, IBacktraceClient
     {
-        public const string VERSION = "3.11.0";
+        public const string VERSION = "3.12.0";
         internal const string DefaultBacktraceGameObjectName = "BacktraceClient";
         public BacktraceConfiguration Configuration;
 

--- a/Runtime/Model/JsonData/Annotations.cs
+++ b/Runtime/Model/JsonData/Annotations.cs
@@ -20,27 +20,17 @@ namespace Backtrace.Unity.Model.JsonData
         internal static Dictionary<string, string> _environmentVariablesCache;
 
         /// <summary>
-        /// Determinate if static helper should load environment variables or not.
-        /// </summary>
-        internal static bool VariablesLoaded;
-
-        /// <summary>
         /// Loaded environment variables
         /// </summary>
         public static Dictionary<string, string> EnvironmentVariablesCache
         {
             get
             {
-                if (VariablesLoaded == false)
-                {
-                    _environmentVariablesCache = SetEnvironmentVariables();
-                    VariablesLoaded = true;
-                }
                 return _environmentVariablesCache;
             }
             set
             {
-                _environmentVariablesCache = value;
+                _environmentVariablesCache = SetEnvironmentVariables(_environmentVariablesCache);
             }
         }
 
@@ -78,10 +68,9 @@ namespace Backtrace.Unity.Model.JsonData
             Exception = exception;
         }
 
-        private static Dictionary<string, string> SetEnvironmentVariables()
+        private static Dictionary<string, string> SetEnvironmentVariables(IDictionary environmentVariables)
         {
             var result = new Dictionary<string, string>();
-            var environmentVariables = Environment.GetEnvironmentVariables();
             if (environmentVariables == null)
             {
                 return result;
@@ -104,7 +93,10 @@ namespace Backtrace.Unity.Model.JsonData
         public BacktraceJObject ToJson()
         {
             var annotations = new BacktraceJObject();
-            annotations.Add("Environment Variables", new BacktraceJObject(EnvironmentVariables));
+            if (EnvironmentVariables != null) 
+            {
+                annotations.Add("Environment Variables", new BacktraceJObject(EnvironmentVariables));
+            }
 
             if (Exception != null)
             {

--- a/Tests/Runtime/ClientSendTests.cs
+++ b/Tests/Runtime/ClientSendTests.cs
@@ -3,6 +3,8 @@ using Backtrace.Unity.Model.JsonData;
 using NUnit.Framework;
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -29,7 +31,7 @@ namespace Backtrace.Unity.Tests.Runtime
         public void Cleanup()
         {
             client.RequestHandler = null;
-            Annotations.VariablesLoaded = false;
+            Annotations.EnvironmentVariablesCache = null;
         }
 
         [UnityTest]
@@ -108,6 +110,9 @@ namespace Backtrace.Unity.Tests.Runtime
 
             var environmentVariableKey = "foo";
             var expectedValue = "bar";
+            Annotations.EnvironmentVariablesCache = Environment.GetEnvironmentVariables()
+                .Cast<DictionaryEntry>()
+                .ToDictionary(entry => (string)entry.Key, entry => entry.Value as string);
             Annotations.EnvironmentVariablesCache[environmentVariableKey] = expectedValue;
 
             client.BeforeSend = (BacktraceData data) =>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "io.backtrace.unity",
   "displayName": "Backtrace",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "unity": "2017.1",
   "description": "Backtrace's integration with Unity games allows customers to capture and report handled and unhandled Unity exceptions to their Backtrace instance, instantly offering the ability to prioritize and debug software errors.",
   "keywords": [


### PR DESCRIPTION
# Why

Environment variables are hard to manage for our users. They can contain PII info/user secrets that are hard to remove on the SDK initialization. To minimalize the risk of submitting something unwanted, this pull request disabled by default env variables and the user (if it needs to) can include them.

ref: INT-80