### PR TITLE
Make env variable optional

### DIFF
--- a/Runtime/Model/JsonData/Annotations.cs
+++ b/Runtime/Model/JsonData/Annotations.cs
@@ -20,27 +20,17 @@ namespace Backtrace.Unity.Model.JsonData
         internal static Dictionary<string, string> _environmentVariablesCache;
 
         /// <summary>
-        /// Determinate if static helper should load environment variables or not.
-        /// </summary>
-        internal static bool VariablesLoaded;
-
-        /// <summary>
         /// Loaded environment variables
         /// </summary>
         public static Dictionary<string, string> EnvironmentVariablesCache
         {
             get
             {
-                if (VariablesLoaded == false)
-                {
-                    _environmentVariablesCache = SetEnvironmentVariables();
-                    VariablesLoaded = true;
-                }
                 return _environmentVariablesCache;
             }
             set
             {
-                _environmentVariablesCache = value;
+                _environmentVariablesCache = SetEnvironmentVariables(_environmentVariablesCache);
             }
         }
 
@@ -78,10 +68,9 @@ namespace Backtrace.Unity.Model.JsonData
             Exception = exception;
         }
 
-        private static Dictionary<string, string> SetEnvironmentVariables()
+        private static Dictionary<string, string> SetEnvironmentVariables(IDictionary environmentVariables)
         {
             var result = new Dictionary<string, string>();
-            var environmentVariables = Environment.GetEnvironmentVariables();
             if (environmentVariables == null)
             {
                 return result;
@@ -104,7 +93,10 @@ namespace Backtrace.Unity.Model.JsonData
         public BacktraceJObject ToJson()
         {
             var annotations = new BacktraceJObject();
-            annotations.Add("Environment Variables", new BacktraceJObject(EnvironmentVariables));
+            if (EnvironmentVariables != null) 
+            {
+                annotations.Add("Environment Variables", new BacktraceJObject(EnvironmentVariables));
+            }
 
             if (Exception != null)
             {

--- a/Tests/Runtime/ClientSendTests.cs
+++ b/Tests/Runtime/ClientSendTests.cs
@@ -3,6 +3,8 @@ using Backtrace.Unity.Model.JsonData;
 using NUnit.Framework;
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.TestTools;
 
@@ -29,7 +31,7 @@ namespace Backtrace.Unity.Tests.Runtime
         public void Cleanup()
         {
             client.RequestHandler = null;
-            Annotations.VariablesLoaded = false;
+            Annotations.EnvironmentVariablesCache = null;
         }
 
         [UnityTest]
@@ -108,6 +110,9 @@ namespace Backtrace.Unity.Tests.Runtime
 
             var environmentVariableKey = "foo";
             var expectedValue = "bar";
+            Annotations.EnvironmentVariablesCache = Environment.GetEnvironmentVariables()
+                .Cast<DictionaryEntry>()
+                .ToDictionary(entry => (string)entry.Key, entry => entry.Value as string);
             Annotations.EnvironmentVariablesCache[environmentVariableKey] = expectedValue;
 
             client.BeforeSend = (BacktraceData data) =>


### PR DESCRIPTION
# Why

Environment variables are hard to manage for our users. They can contain PII info/user secrets that are hard to remove on the SDK initialization. To minimalize the risk of submitting something unwanted, this pull request disabled by default env variables and the user (if it needs to) can include them.

ref: INT-80