### PR TITLE
Add data providers metadata

### DIFF
--- a/Runtime/Model/DataProvider/IMachineIdentifierProvider.cs.meta
+++ b/Runtime/Model/DataProvider/IMachineIdentifierProvider.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: e94db95360eabe94a8f901670f630ab9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Model/DataProvider/ISessionStorageDataProvider.cs.meta
+++ b/Runtime/Model/DataProvider/ISessionStorageDataProvider.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 79226154fe224d84b9f0014d5c8a4206
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Model/DataProvider/NetworkIdentifierProvider.cs.meta
+++ b/Runtime/Model/DataProvider/NetworkIdentifierProvider.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 92eddf6f5fcf68d489027eabf6b0d935
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Model/DataProvider/SessionStorageDataProvider.cs.meta
+++ b/Runtime/Model/DataProvider/SessionStorageDataProvider.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 61658e4a3b261f940a5497ad0125d81f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Model/DataProvider/UnityMachineIdentifierProvider.cs.meta
+++ b/Runtime/Model/DataProvider/UnityMachineIdentifierProvider.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: ed39481d15e8b2249875498830f31c6f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# Why

The new unique id provider was developed on Windows. Somehow, the Unity editor there didn't add proper metadata annotations. This pull request extends the default Unity metadata generated by the Unity Editor on Mac