### PR TITLE
Restore .meta 'Is16KbAligned' flag

### DIFF
--- a/Android/lib/arm64-v8a/libbacktrace-native.so.meta
+++ b/Android/lib/arm64-v8a/libbacktrace-native.so.meta
@@ -23,6 +23,7 @@ PluginImporter:
       enabled: 1
       settings:
         CPU: ARM64
+        Is16KbAligned: true
   - first:
       Editor: Editor
     second:

--- a/Android/lib/arm64-v8a/libnative-lib.so.meta
+++ b/Android/lib/arm64-v8a/libnative-lib.so.meta
@@ -23,6 +23,7 @@ PluginImporter:
       enabled: 1
       settings:
         CPU: ARM64
+        Is16KbAligned: true
   - first:
       Editor: Editor
     second:

--- a/Android/lib/armeabi-v7a/libbacktrace-native.so.meta
+++ b/Android/lib/armeabi-v7a/libbacktrace-native.so.meta
@@ -23,6 +23,7 @@ PluginImporter:
       enabled: 1
       settings:
         CPU: ARMv7
+        Is16KbAligned: true
   - first:
       Editor: Editor
     second:

--- a/Android/lib/armeabi-v7a/libnative-lib.so.meta
+++ b/Android/lib/armeabi-v7a/libnative-lib.so.meta
@@ -23,6 +23,7 @@ PluginImporter:
       enabled: 1
       settings:
         CPU: ARMv7
+        Is16KbAligned: true
   - first:
       Editor: Editor
     second:

--- a/Android/lib/x86/libbacktrace-native.so.meta
+++ b/Android/lib/x86/libbacktrace-native.so.meta
@@ -23,6 +23,7 @@ PluginImporter:
       enabled: 1
       settings:
         CPU: x86
+        Is16KbAligned: true
   - first:
       Editor: Editor
     second:

--- a/Android/lib/x86/libnative-lib.so.meta
+++ b/Android/lib/x86/libnative-lib.so.meta
@@ -23,6 +23,7 @@ PluginImporter:
       enabled: 1
       settings:
         CPU: x86
+        Is16KbAligned: true
   - first:
       Editor: Editor
     second:

--- a/Android/lib/x86_64/libbacktrace-native.so.meta
+++ b/Android/lib/x86_64/libbacktrace-native.so.meta
@@ -23,6 +23,7 @@ PluginImporter:
       enabled: 1
       settings:
         CPU: x86_64
+        Is16KbAligned: true
   - first:
       Editor: Editor
     second:

--- a/Android/lib/x86_64/libnative-lib.so.meta
+++ b/Android/lib/x86_64/libnative-lib.so.meta
@@ -23,6 +23,7 @@ PluginImporter:
       enabled: 1
       settings:
         CPU: x86_64
+        Is16KbAligned: true
   - first:
       Editor: Editor
     second:


### PR DESCRIPTION
Some Unity Editors raise a warning about "Is16KbAligned" when it's not included in the metadata files, This PR restores 'Is16KbAligned' flag.

ref: BT-6078