### PR TITLE
Unity 6.5+: Handle GetInstanceID deprecation

### DIFF
--- a/Runtime/Model/JsonData/Annotations.cs
+++ b/Runtime/Model/JsonData/Annotations.cs
@@ -178,7 +178,12 @@ namespace Backtrace.Unity.Model.JsonData
                 { "tag",gameObject.tag},
                 { "activeInHierarchy", gameObject.activeInHierarchy.ToString(CultureInfo.InvariantCulture).ToLower()},
                 { "activeSelf",  gameObject.activeSelf.ToString(CultureInfo.InvariantCulture).ToLower() },
+
+#if UNITY_6000_5_OR_NEWER
+                { "instanceId", gameObject.GetEntityId().ToString() },
+#else
                 { "instanceId", gameObject.GetInstanceID().ToString(CultureInfo.InvariantCulture) },
+#endif
                 { "parentName", string.IsNullOrEmpty(parentName) ? "root object" : parentName }
             });
         }
@@ -190,7 +195,11 @@ namespace Backtrace.Unity.Model.JsonData
                 { "transform.position", gameObject.transform.position.ToString()},
                 { "transform.rotation", gameObject.transform.rotation.ToString()},
                 { "tag",gameObject.tag},
+#if UNITY_6000_5_OR_NEWER
+                { "instanceId", gameObject.GetEntityId().ToString() },
+#else
                 { "instanceId", gameObject.GetInstanceID().ToString(CultureInfo.InvariantCulture) },
+#endif
                 { "parentName", string.IsNullOrEmpty(parentName) ? "root object" : parentName }
             });
         }


### PR DESCRIPTION
### Summary
`Unity 6.5` deprecates `GetInstanceID()`. This change updates `Annotations.cs` to use the new `GetEntityId()` API when building with `Unity 6.5+` while keeping the existing behaviour for older Unity versions.

### Changes
Update `GetJObject` overloads to version-gate `instanceId`:
- **Unity 6.5+ (UNITY_6000_5_OR_NEWER)**: Uses the new `GetEntityId()` API.
- **Older Unity versions**: Keeps the existing `GetInstanceID(`) call unchanged

### Links
- [Planned breaking changes in Unity 6.5 [updated 2026-02-03]](https://discussions.unity.com/t/planned-breaking-changes-in-unity-6-5-updated-2026-02-03/1694205)
- [GetInstanceId() deprecation](https://discussions.unity.com/t/getinstanceid-deprecation/1705258)


[Sample-Reports](https://share.backtrace.io/api/share/gSf2vHgDWRmDNRdibWaIE2)

ref: BT-6384