### PR TITLE
CI/CD build pipeline - fix logging and improve free disk step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    name: Run Build for ${{ matrix.unityVersion }} ${{ matrix.unityVersion }}
+    name: Run Build for ${{ matrix.unityVersion }} ${{ matrix.targetPlatform }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -35,7 +35,8 @@ jobs:
           mkdir ${{ matrix.projectPath }}
           mv Editor Runtime Tests Android iOS Windows package.json ${{ matrix.projectPath }}/
 
-      - if: matrix.targetPlatform == 'Android'
+      - name: Free disk space (Android only)
+        if: matrix.targetPlatform == 'Android'
         uses: jlumbroso/free-disk-space@v1.3.1
 
       - uses: game-ci/unity-builder@v4


### PR DESCRIPTION
## Summary

Fixes build step naming and improves disk space handling in the CI pipeline.

### Changes
- Corrected build step name to include targetPlatform instead of duplicating unityVersion
- Added a name for "Free disk space" step for Android builds only

### Why
- Improves clarity of build logs (better step naming)
- Makes CI behavior more explicit and easier to debug