### PR TITLE
Add Validate packaged macOS framework layout job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
         projectPath:
           - test-package
         unityVersion:
-          - 2019.4.40f1
+          - 2021.3.56f2
         targetPlatform:
           - StandaloneOSX
           - StandaloneWindows

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,77 @@ on:
   pull_request:
 
 jobs:
+  validate-macos-framework-layout:
+    name: Validate macOS framework layout
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - name: Validate Backtrace.framework layout in repo
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          FRAMEWORK="Mac/BacktraceMacUnity.bundle/Contents/Frameworks/Backtrace.framework"
+
+          test -d "$FRAMEWORK"
+          test -d "$FRAMEWORK/Versions/A"
+          test -f "$FRAMEWORK/Versions/A/Backtrace"
+          test -f "$FRAMEWORK/Versions/A/Resources/Info.plist"
+
+          test -L "$FRAMEWORK/Versions/Current"
+          test "$(readlink "$FRAMEWORK/Versions/Current")" = "A"
+
+          test -L "$FRAMEWORK/Backtrace"
+          test "$(readlink "$FRAMEWORK/Backtrace")" = "Versions/Current/Backtrace"
+
+          test -L "$FRAMEWORK/Resources"
+          test "$(readlink "$FRAMEWORK/Resources")" = "Versions/Current/Resources"
+
+          test ! -e "$FRAMEWORK/A"
+
+      - name: Validate packaged macOS framework layout
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          WORKDIR="$(mktemp -d)"
+          PACKAGE_ROOT="$WORKDIR/package-root"
+          mkdir -p "$PACKAGE_ROOT"
+
+          cp -R Editor Runtime Tests Android iOS Mac Windows package.json "$PACKAGE_ROOT/"
+
+          tar -czf "$WORKDIR/io.backtrace.unity.tgz" -C "$PACKAGE_ROOT" .
+
+          EXTRACT_DIR="$WORKDIR/extracted"
+          mkdir -p "$EXTRACT_DIR"
+          tar -xzf "$WORKDIR/io.backtrace.unity.tgz" -C "$EXTRACT_DIR"
+
+          FRAMEWORK="$EXTRACT_DIR/Mac/BacktraceMacUnity.bundle/Contents/Frameworks/Backtrace.framework"
+
+          test -d "$FRAMEWORK"
+          test -d "$FRAMEWORK/Versions/A"
+          test -f "$FRAMEWORK/Versions/A/Backtrace"
+          test -f "$FRAMEWORK/Versions/A/Resources/Info.plist"
+
+          test -L "$FRAMEWORK/Versions/Current"
+          test "$(readlink "$FRAMEWORK/Versions/Current")" = "A"
+
+          test -L "$FRAMEWORK/Backtrace"
+          test "$(readlink "$FRAMEWORK/Backtrace")" = "Versions/Current/Backtrace"
+
+          test -L "$FRAMEWORK/Resources"
+          test "$(readlink "$FRAMEWORK/Resources")" = "Versions/Current/Resources"
+
+          test ! -e "$FRAMEWORK/A"
+
   test:
-    name: Run Build for ${{ matrix.unityVersion }} ${{ matrix.targetPlatform }}
+    needs: validate-macos-framework-layout
+    name: Run Build for ${{ matrix.unityVersion }} ${{ matrix.unityVersion }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -24,6 +93,7 @@ jobs:
           - iOS
           - Android
           - WebGL
+
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -33,10 +103,9 @@ jobs:
       - name: Setup Environment
         run: |
           mkdir ${{ matrix.projectPath }}
-          mv Editor Runtime Tests Android iOS Windows package.json ${{ matrix.projectPath }}/
+          mv Editor Runtime Tests Android iOS Mac Windows package.json ${{ matrix.projectPath }}/
 
-      - name: Free disk space (Android only)
-        if: matrix.targetPlatform == 'Android'
+      - if: matrix.targetPlatform == 'Android'
         uses: jlumbroso/free-disk-space@v1.3.1
 
       - uses: game-ci/unity-builder@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
         projectPath:
           - test-package
         unityVersion:
-          - 2021.3.56f2
+          - 2019.4.40f1
         targetPlatform:
           - StandaloneOSX
           - StandaloneWindows

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
         projectPath:
           - test-package
         unityVersion:
+          - 2019.4.40f1
           - 2021.3.56f2
           - 2022.3.56f1
           - 6000.3.7f1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,6 @@ jobs:
         projectPath:
           - test-package
         unityVersion:
-          - 2019.4.40f1
           - 2021.3.56f2
           - 2022.3.56f1
           - 6000.3.7f1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Environment
         run: |
           mkdir ${{ matrix.projectPath }}
-          mv Editor Runtime Tests Android iOS Windows package.json ${{ matrix.projectPath }}/
+          mv Editor Runtime Tests Android iOS Mac Windows package.json ${{ matrix.projectPath }}/
 
       - name: Run Tests
         uses: game-ci/unity-test-runner@v4


### PR DESCRIPTION
### Maintenance
- Add CI validation for the macOS `Backtrace.framework` versioned bundle layout and include `Mac/` in the package-under-test to prevent regressions in the GitHub release artifact.
- [Remove legacy unityVersion 2019.4.40f1](https://github.com/backtrace-labs/backtrace-unity/pull/280/commits/9fe70d5b1233fedbf418a55afa065b9e797df1cb)

ref: BT-6665