### PR TITLE
fix(unity): preserve report error.type classification

### DIFF
--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -1291,14 +1291,6 @@ namespace Backtrace.Unity
                         : ReportFilterType.Error;
             }
 
-            string capturePath;
-            if (report.Attributes != null &&
-                report.Attributes.TryGetValue("backtrace.unity.capture_path", out capturePath) &&
-                BacktraceUnityLogCapture.IsLogHandlerAndCallbackCapturePath(capturePath))
-            {
-                return ReportFilterType.UnhandledException;
-            }
-
             string unityLogType;
             if (report.Attributes != null &&
                 report.Attributes.TryGetValue("backtrace.unity.log.type", out unityLogType))

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -1030,12 +1030,11 @@ namespace Backtrace.Unity
         /// <summary>
         /// Create report data with client/native attributes applied as defaults.
         /// Report-specific attributes must win over client-scoped and dynamic
-        /// attributes because values such as error.type and error.message are
-        /// properties of the report, not of the process.
+        /// attributes because values such as error.type, error.message, and
+        /// _mod_fingerprint are properties of the report, not of the process.
         ///
         /// This prevents native Apple crash attributes such as error.type=Crash from
-        /// overriding managed Unity exception reports that should be classified as
-        /// error.type=Unhandled exception.
+        /// overriding managed Unity report classification.
         /// </summary>
         private BacktraceData CreateBacktraceDataWithClientAttributes(BacktraceReport report)
         {

--- a/Runtime/BacktraceClient.cs
+++ b/Runtime/BacktraceClient.cs
@@ -1024,11 +1024,24 @@ namespace Backtrace.Unity
             report.SetReportFingerprint(Configuration.UseNormalizedExceptionMessage);
             report.AttachmentPaths.AddRange(_clientReportAttachments);
 
-            // pass copy of dictionary to prevent overriding client attributes
-            var result = report.ToBacktraceData(null, GameObjectDepth);
-            AttributeProvider.AddAttributes(result.Attributes.Attributes);
+            return CreateBacktraceDataWithClientAttributes(report);
+        }
 
-            return result;
+        /// <summary>
+        /// Create report data with client/native attributes applied as defaults.
+        /// Report-specific attributes must win over client-scoped and dynamic
+        /// attributes because values such as error.type and error.message are
+        /// properties of the report, not of the process.
+        ///
+        /// This prevents native Apple crash attributes such as error.type=Crash from
+        /// overriding managed Unity exception reports that should be classified as
+        /// error.type=Unhandled exception.
+        /// </summary>
+        private BacktraceData CreateBacktraceDataWithClientAttributes(BacktraceReport report)
+        {
+            var clientAttributes = new Dictionary<string, string>(
+                AttributeProvider.GenerateAttributes());
+            return report.ToBacktraceData(clientAttributes, GameObjectDepth);
         }
 
 #if UNITY_ANDROID
@@ -1078,8 +1091,7 @@ namespace Backtrace.Unity
             
             if (Database != null)
             {
-                var backtraceData = report.ToBacktraceData(null, GameObjectDepth);
-                AttributeProvider.AddAttributes(backtraceData.Attributes.Attributes);
+                var backtraceData = CreateBacktraceDataWithClientAttributes(report);
                 Database.Add(backtraceData);
             }
             else

--- a/Runtime/Model/BacktraceUnityLogReportFactory.cs
+++ b/Runtime/Model/BacktraceUnityLogReportFactory.cs
@@ -218,6 +218,8 @@ namespace Backtrace.Unity.Model
             var report = BacktraceReport.CreateWithoutEnvironmentStackFallback(
                 exception,
                 attributes);
+            report.Attributes["error.type"] =
+                BacktraceDefaultClassifierTypes.UnhandledExceptionType;
             report.Attributes["error.message"] = message;
             return report;
         }

--- a/Runtime/Native/OSX/NativeClient.cs
+++ b/Runtime/Native/OSX/NativeClient.cs
@@ -17,7 +17,7 @@ namespace Backtrace.Unity.Runtime.Native.OSX
     /// </summary>
     internal class NativeClient : NativeClientBase, INativeClient
     {
-        // NSDictinary entry used only for OSX native integration
+        // NSDictionary entry used only for OSX native integration
         [StructLayout(LayoutKind.Sequential)]
         internal struct Entry
         {

--- a/Runtime/Native/OSX/NativeClient.cs
+++ b/Runtime/Native/OSX/NativeClient.cs
@@ -18,9 +18,13 @@ namespace Backtrace.Unity.Runtime.Native.OSX
     internal class NativeClient : NativeClientBase, INativeClient
     {
         // NSDictinary entry used only for OSX native integration
+        [StructLayout(LayoutKind.Sequential)]
         internal struct Entry
         {
+            [MarshalAs(UnmanagedType.LPStr)]
             public string Key;
+
+            [MarshalAs(UnmanagedType.LPStr)]
             public string Value;
         }
 
@@ -141,10 +145,9 @@ namespace Backtrace.Unity.Runtime.Native.OSX
                     }
                     Entry entry = (Entry)Marshal.PtrToStructure(address, typeof(Entry));
                     // The native macOS client keeps error.type=Crash so PLCrashReporter
-                    // crash and OOM payloads are classified correctly. That value is
-                    // not a process/client attribute and must not be copied back into
-                    // managed C# reports, otherwise Unity handled exceptions are
-                    // mislabeled as crashes.
+                    // crash payloads are classified correctly. That value is not a
+                    // process/client attribute and must not be copied back into
+                    // managed C# reports.
                     if (string.IsNullOrEmpty(entry.Key) ||
                         string.Equals(entry.Key, ErrorTypeAttribute, StringComparison.Ordinal))
                     {

--- a/Runtime/Native/OSX/NativeClient.cs
+++ b/Runtime/Native/OSX/NativeClient.cs
@@ -106,39 +106,57 @@ namespace Backtrace.Unity.Runtime.Native.OSX
         }
 
         /// <summary>
-        /// Retrieve Backtrace Attributes from the Android native code.
+        /// Retrieve Backtrace Attributes from the macOS native code.
         /// </summary>
-        /// <returns>Backtrace Attributes from the Android build</returns>
+        /// <returns>Backtrace Attributes from the macOS build</returns>
         public void GetAttributes(IDictionary<string, string> result)
         {
-            if (!_enabled)
+            if (!_enabled || result == null)
             {
                 return;
             }
             IntPtr pUnmanagedArray;
             int keysCount;
             GetNativeAttributes(out pUnmanagedArray, out keysCount);
-
-            // calculate struct size for current OS.
-            // We multiply by 2 because Entry struct has two pointers
-            var structSize = IntPtr.Size * 2;
-            const int x86StructSize = 4;
-            for (int i = 0; i < keysCount; i++)
+            if (pUnmanagedArray == IntPtr.Zero || keysCount <= 0)
             {
-                IntPtr address;
-                if (structSize == x86StructSize)
-                {
-                    address = new IntPtr(pUnmanagedArray.ToInt32() + i * structSize);
-                }
-                else
-                {
-                    address = new IntPtr(pUnmanagedArray.ToInt64() + i * structSize);
-                }
-                Entry entry = (Entry)Marshal.PtrToStructure(address, typeof(Entry));
-                result[entry.Key] = entry.Value;
+                return;
             }
-
-            Marshal.FreeHGlobal(pUnmanagedArray);
+            try
+            {
+                // calculate struct size for current OS.
+                // We multiply by 2 because Entry struct has two pointers
+                var structSize = IntPtr.Size * 2;
+                const int x86StructSize = 4;
+                for (int i = 0; i < keysCount; i++)
+                {
+                    IntPtr address;
+                    if (structSize == x86StructSize)
+                    {
+                        address = new IntPtr(pUnmanagedArray.ToInt32() + i * structSize);
+                    }
+                    else
+                    {
+                        address = new IntPtr(pUnmanagedArray.ToInt64() + i * structSize);
+                    }
+                    Entry entry = (Entry)Marshal.PtrToStructure(address, typeof(Entry));
+                    // The native macOS client keeps error.type=Crash so PLCrashReporter
+                    // crash and OOM payloads are classified correctly. That value is
+                    // not a process/client attribute and must not be copied back into
+                    // managed C# reports, otherwise Unity handled exceptions are
+                    // mislabeled as crashes.
+                    if (string.IsNullOrEmpty(entry.Key) ||
+                        string.Equals(entry.Key, ErrorTypeAttribute, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+                    result[entry.Key] = entry.Value;
+                }
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(pUnmanagedArray);
+            }
         }
 
         /// <summary>

--- a/Runtime/Native/iOS/NativeClient.cs
+++ b/Runtime/Native/iOS/NativeClient.cs
@@ -18,9 +18,13 @@ namespace Backtrace.Unity.Runtime.Native.iOS
     internal class NativeClient : NativeClientBase, INativeClient
     {
         // NSDictinary entry used only for iOS native integration
+        [StructLayout(LayoutKind.Sequential)]
         internal struct Entry
         {
+            [MarshalAs(UnmanagedType.LPStr)]
             public string Key;
+
+            [MarshalAs(UnmanagedType.LPStr)]
             public string Value;
         }
 
@@ -35,6 +39,9 @@ namespace Backtrace.Unity.Runtime.Native.iOS
 
         [DllImport("__Internal", EntryPoint = "GetAttributes")]
         private static extern void GetNativeAttributes(out IntPtr attributes, out int keysCount);
+
+        [DllImport("__Internal", EntryPoint = "FreeAttributes")]
+        private static extern void FreeNativeAttributes(IntPtr attributes, int keysCount);
 
         [DllImport("__Internal", EntryPoint = "AddAttribute")]
         private static extern void AddAttribute(string key, string value);
@@ -136,10 +143,9 @@ namespace Backtrace.Unity.Runtime.Native.iOS
                     }
                     Entry entry = (Entry)Marshal.PtrToStructure(address, typeof(Entry));
                     // The native iOS client keeps error.type=Crash so PLCrashReporter
-                    // crash and OOM payloads are classified correctly. That value is
-                    // not a process/client attribute and must not be copied back into
-                    // managed C# reports, otherwise Unity handled exceptions are
-                    // mislabeled as crashes.
+                    // crash payloads are classified correctly. That value is not a
+                    // process/client attribute and must not be copied back into
+                    // managed C# reports.
                     if (string.IsNullOrEmpty(entry.Key) ||
                         string.Equals(entry.Key, ErrorTypeAttribute, StringComparison.Ordinal))
                     {
@@ -150,7 +156,7 @@ namespace Backtrace.Unity.Runtime.Native.iOS
             }
             finally
             {
-                Marshal.FreeHGlobal(pUnmanagedArray);
+                FreeNativeAttributes(pUnmanagedArray, keysCount);
             }
         }
 

--- a/Runtime/Native/iOS/NativeClient.cs
+++ b/Runtime/Native/iOS/NativeClient.cs
@@ -101,39 +101,57 @@ namespace Backtrace.Unity.Runtime.Native.iOS
         }
 
         /// <summary>
-        /// Retrieve Backtrace Attributes from the Android native code.
+        /// Retrieve Backtrace Attributes from the iOS native code.
         /// </summary>
-        /// <returns>Backtrace Attributes from the Android build</returns>
+        /// <returns>Backtrace Attributes from the iOS build</returns>
         public void GetAttributes(IDictionary<string, string> result)
         {
-            if (!_enabled)
+            if (!_enabled || result == null)
             {
                 return;
             }
             IntPtr pUnmanagedArray;
             int keysCount;
             GetNativeAttributes(out pUnmanagedArray, out keysCount);
-
-            // calculate struct size for current OS.
-            // We multiply by 2 because Entry struct has two pointers
-            var structSize = IntPtr.Size * 2;
-            const int x86StructSize = 4;
-            for (int i = 0; i < keysCount; i++)
+            if (pUnmanagedArray == IntPtr.Zero || keysCount <= 0)
             {
-                IntPtr address;
-                if (structSize == x86StructSize)
-                {
-                    address = new IntPtr(pUnmanagedArray.ToInt32() + i * structSize);
-                }
-                else
-                {
-                    address = new IntPtr(pUnmanagedArray.ToInt64() + i * structSize);
-                }
-                Entry entry = (Entry)Marshal.PtrToStructure(address, typeof(Entry));
-                result[entry.Key] = entry.Value;
+                return;
             }
-
-            Marshal.FreeHGlobal(pUnmanagedArray);
+            try
+            {
+                // calculate struct size for current OS.
+                // We multiply by 2 because Entry struct has two pointers
+                var structSize = IntPtr.Size * 2;
+                const int x86StructSize = 4;
+                for (int i = 0; i < keysCount; i++)
+                {
+                    IntPtr address;
+                    if (structSize == x86StructSize)
+                    {
+                        address = new IntPtr(pUnmanagedArray.ToInt32() + i * structSize);
+                    }
+                    else
+                    {
+                        address = new IntPtr(pUnmanagedArray.ToInt64() + i * structSize);
+                    }
+                    Entry entry = (Entry)Marshal.PtrToStructure(address, typeof(Entry));
+                    // The native iOS client keeps error.type=Crash so PLCrashReporter
+                    // crash and OOM payloads are classified correctly. That value is
+                    // not a process/client attribute and must not be copied back into
+                    // managed C# reports, otherwise Unity handled exceptions are
+                    // mislabeled as crashes.
+                    if (string.IsNullOrEmpty(entry.Key) ||
+                        string.Equals(entry.Key, ErrorTypeAttribute, StringComparison.Ordinal))
+                    {
+                        continue;
+                    }
+                    result[entry.Key] = entry.Value;
+                }
+            }
+            finally
+            {
+                Marshal.FreeHGlobal(pUnmanagedArray);
+            }
         }
 
         /// <summary>

--- a/Tests/Runtime/BacktraceAttributeTests.cs
+++ b/Tests/Runtime/BacktraceAttributeTests.cs
@@ -263,6 +263,29 @@ namespace Backtrace.Unity.Tests.Runtime
             Assert.AreEqual("Exception", data.Attributes.Attributes["error.type"]);
         }
 
+        [UnityTest]
+        public IEnumerator TestExplicitSendException_ShouldRemainHandledException_WhenDynamicErrorTypeIsCrash()
+        {
+            BacktraceClient.AttributeProvider.AddDynamicAttributeProvider(
+                new TestDynamicAttributeProvider(new Dictionary<string, string>
+                {
+                    { "error.type", "Crash" },
+                    { "native.attribute", "native-value" }
+                }));
+            BacktraceData data = null;
+            BacktraceClient.BeforeSend = (BacktraceData reportData) =>
+            {
+                data = reportData;
+                return null;
+            };
+            BacktraceClient.Send(new InvalidOperationException("Handled exception"));
+            yield return WaitForFrame.Wait();
+            Assert.IsNotNull(data);
+            Assert.AreEqual("Exception", data.Attributes.Attributes["error.type"]);
+            Assert.AreEqual("native-value", data.Attributes.Attributes["native.attribute"]);
+            Assert.IsFalse(data.Attributes.Attributes.ContainsKey("backtrace.unity.capture_path"));
+        }
+
         private sealed class TestDynamicAttributeProvider : IDynamicAttributeProvider
         {
             private readonly IDictionary<string, string> _attributes;

--- a/Tests/Runtime/BacktraceAttributeTests.cs
+++ b/Tests/Runtime/BacktraceAttributeTests.cs
@@ -1,4 +1,5 @@
-﻿using Backtrace.Unity.Model;
+﻿using Backtrace.Unity.Extensions;
+using Backtrace.Unity.Model;
 using Backtrace.Unity.Model.Attributes;
 using Backtrace.Unity.Model.JsonData;
 using NUnit.Framework;
@@ -198,27 +199,77 @@ namespace Backtrace.Unity.Tests.Runtime
         }
 
         [UnityTest]
-        public IEnumerator TestReportAttributes_ShouldOverrideDynamicClientAttributes_ErrorTypeIsReportScoped()
+        public IEnumerator TestReportAttributes_ShouldOverrideDynamicClientAttributes_ReportScopedAttributesWin()
         {
+            const string message =
+                "NullReferenceException: Object reference not set to an instance of an object.";
+
             BacktraceClient.AttributeProvider.AddDynamicAttributeProvider(
                 new TestDynamicAttributeProvider(new Dictionary<string, string>
                 {
                     { "error.type", "Crash" },
+                    { "error.message", "native-message" },
                     { "native.attribute", "native-value" }
                 }));
+
             BacktraceData data = null;
             BacktraceClient.BeforeSend = (BacktraceData reportData) =>
             {
                 data = reportData;
                 return null;
             };
+
             BacktraceClient.Send(new BacktraceUnhandledException(
-                "NullReferenceException: Object reference not set to an instance of an object.",
+                message,
                 "Example.Thrower () (at Assets/Example.cs:12)"));
+
             yield return WaitForFrame.Wait();
+
             Assert.IsNotNull(data);
-            Assert.AreEqual("Unhandled exception", data.Attributes.Attributes["error.type"]);
-            Assert.AreEqual("native-value", data.Attributes.Attributes["native.attribute"]);
+            Assert.AreEqual(
+                "Unhandled exception",
+                data.Attributes.Attributes["error.type"]);
+            Assert.AreEqual(
+                message,
+                data.Attributes.Attributes["error.message"]);
+            Assert.AreEqual(
+                "native-value",
+                data.Attributes.Attributes["native.attribute"]);
+        }
+
+        [UnityTest]
+        public IEnumerator TestReportAttributes_ShouldOverrideDynamicClientAttributes_ModFingerprintIsReportScoped()
+        {
+            const string message = "Unhandledexception";
+
+            BacktraceClient.Configuration.UseNormalizedExceptionMessage = true;
+            BacktraceClient.AttributeProvider.AddDynamicAttributeProvider(
+                new TestDynamicAttributeProvider(new Dictionary<string, string>
+                {
+                    { "_mod_fingerprint", "native-fingerprint" }
+                }));
+
+            BacktraceData data = null;
+            BacktraceClient.BeforeSend = (BacktraceData reportData) =>
+            {
+                data = reportData;
+                return null;
+            };
+
+            BacktraceClient.Send(new BacktraceUnhandledException(
+                message,
+                string.Empty));
+
+            yield return WaitForFrame.Wait();
+
+            Assert.IsNotNull(data);
+            Assert.IsTrue(data.Attributes.Attributes.ContainsKey("_mod_fingerprint"));
+            Assert.AreEqual(
+                message.GetSha(),
+                data.Attributes.Attributes["_mod_fingerprint"]);
+            Assert.AreNotEqual(
+                "native-fingerprint",
+                data.Attributes.Attributes["_mod_fingerprint"]);
         }
 
         [UnityTest]

--- a/Tests/Runtime/BacktraceAttributeTests.cs
+++ b/Tests/Runtime/BacktraceAttributeTests.cs
@@ -1,4 +1,5 @@
 ﻿using Backtrace.Unity.Model;
+using Backtrace.Unity.Model.Attributes;
 using Backtrace.Unity.Model.JsonData;
 using NUnit.Framework;
 using System;
@@ -194,6 +195,88 @@ namespace Backtrace.Unity.Tests.Runtime
             var testAttributes = new BacktraceAttributes(report, null);
 
             Assert.AreEqual("Hang", testAttributes.Attributes["error.type"]);
+        }
+
+        [UnityTest]
+        public IEnumerator TestReportAttributes_ShouldOverrideDynamicClientAttributes_ErrorTypeIsReportScoped()
+        {
+            BacktraceClient.AttributeProvider.AddDynamicAttributeProvider(
+                new TestDynamicAttributeProvider(new Dictionary<string, string>
+                {
+                    { "error.type", "Crash" },
+                    { "native.attribute", "native-value" }
+                }));
+            BacktraceData data = null;
+            BacktraceClient.BeforeSend = (BacktraceData reportData) =>
+            {
+                data = reportData;
+                return null;
+            };
+            BacktraceClient.Send(new BacktraceUnhandledException(
+                "NullReferenceException: Object reference not set to an instance of an object.",
+                "Example.Thrower () (at Assets/Example.cs:12)"));
+            yield return WaitForFrame.Wait();
+            Assert.IsNotNull(data);
+            Assert.AreEqual("Unhandled exception", data.Attributes.Attributes["error.type"]);
+            Assert.AreEqual("native-value", data.Attributes.Attributes["native.attribute"]);
+        }
+
+        [UnityTest]
+        public IEnumerator TestReportAttributes_ShouldPreserveHangClassification_WhenDynamicClientErrorTypeIsCrash()
+        {
+            BacktraceClient.AttributeProvider.AddDynamicAttributeProvider(
+                new TestDynamicAttributeProvider(new Dictionary<string, string>
+                {
+                    { "error.type", "Crash" }
+                }));
+            BacktraceData data = null;
+            BacktraceClient.BeforeSend = (BacktraceData reportData) =>
+            {
+                data = reportData;
+                return null;
+            };
+            BacktraceClient.Send(new BacktraceUnhandledException(
+                "ANRException: Blocked thread detected.",
+                "Example.BlockedMainThread () (at Assets/Example.cs:24)"));
+            yield return WaitForFrame.Wait();
+            Assert.IsNotNull(data);
+            Assert.AreEqual("Hang", data.Attributes.Attributes["error.type"]);
+        }
+
+        [UnityTest]
+        public IEnumerator TestReportAttributes_ShouldPreserveExceptionClassification_WhenDynamicClientErrorTypeIsCrash()
+        {
+            BacktraceClient.AttributeProvider.AddDynamicAttributeProvider(
+                new TestDynamicAttributeProvider(new Dictionary<string, string>
+                {
+                    { "error.type", "Crash" }
+                }));
+            BacktraceData data = null;
+            BacktraceClient.BeforeSend = (BacktraceData reportData) =>
+            {
+                data = reportData;
+                return null;
+            };
+            BacktraceClient.Send(new FileNotFoundException("Missing asset"));
+            yield return WaitForFrame.Wait();
+            Assert.IsNotNull(data);
+            Assert.AreEqual("Exception", data.Attributes.Attributes["error.type"]);
+        }
+
+        private sealed class TestDynamicAttributeProvider : IDynamicAttributeProvider
+        {
+            private readonly IDictionary<string, string> _attributes;
+            internal TestDynamicAttributeProvider(IDictionary<string, string> attributes)
+            {
+                _attributes = attributes;
+            }
+            public void GetAttributes(IDictionary<string, string> attributes)
+            {
+                foreach (var attribute in _attributes)
+                {
+                    attributes[attribute.Key] = attribute.Value;
+                }
+            }
         }
     }
 }

--- a/Tests/Runtime/BacktraceUnityLogReportFactoryTests.cs
+++ b/Tests/Runtime/BacktraceUnityLogReportFactoryTests.cs
@@ -43,6 +43,7 @@ namespace Backtrace.Unity.Tests.Runtime
             Assert.AreEqual(
                 "true",
                 report.Attributes["backtrace.unity.report.frames.empty"]);
+            Assert.AreEqual("Unhandled exception", report.Attributes["error.type"]);
         }
 
         [Test]
@@ -91,6 +92,7 @@ namespace Backtrace.Unity.Tests.Runtime
                 report.Attributes["backtrace.unity.report.frames.empty"]);
             Assert.False(
                 report.Attributes.ContainsKey("backtrace.unity.stackless.reason"));
+            Assert.AreEqual("Unhandled exception", report.Attributes["error.type"]);
         }
 
         [Test]
@@ -121,6 +123,66 @@ namespace Backtrace.Unity.Tests.Runtime
             Assert.AreEqual(
                 "false",
                 report.Attributes["backtrace.unity.original_exception.stack_present"]);
+            Assert.AreEqual("Unhandled exception", report.Attributes["error.type"]);
+        }
+
+        [Test]
+        public void UnityCallbackOnlyWithStack_ShouldRemainUnhandledException()
+        {
+            var configuration = ScriptableObject.CreateInstance<BacktraceConfiguration>();
+            var factory = new BacktraceUnityLogReportFactory(configuration);
+            var report = factory.CreateReport(
+                "NullReferenceException: Object reference not set to an instance of an object.",
+                "ExampleClass.DoWork() (at Assets/ExampleClass.cs:42)",
+                LogType.Exception,
+                true,
+                BacktraceUnityLogCapture.CapturePathUnityLogMessageReceived,
+                null);
+            Assert.AreEqual("Unhandled exception", report.Attributes["error.type"]);
+        }
+
+        [Test]
+        public void CandidateReport_ShouldRemainUnhandledExceptionBecauseLogHandlerIsMetadataOnly()
+        {
+            var configuration = ScriptableObject.CreateInstance<BacktraceConfiguration>();
+            var factory = new BacktraceUnityLogReportFactory(configuration);
+
+            Exception exception = null;
+            try
+            {
+                throw new NullReferenceException(
+                    "Object reference not set to an instance of an object.");
+            }
+            catch (Exception caught)
+            {
+                exception = caught;
+            }
+
+            var candidate = new BacktraceUnityLogExceptionCandidate
+            {
+                Exception = exception,
+                ContextName = "TestContext",
+                IsMainThread = true,
+                ThreadId = 1
+            };
+
+            var report = factory.CreateReport(
+                "NullReferenceException: Object reference not set to an instance of an object.",
+                "ExampleClass.DoWork() (at Assets/ExampleClass.cs:42)",
+                LogType.Exception,
+                true,
+                BacktraceUnityLogCapture.CapturePathUnityLogMessageReceived,
+                candidate);
+
+            Assert.AreEqual(
+                "Unhandled exception",
+                report.Attributes["error.type"]);
+            Assert.AreEqual(
+                BacktraceUnityLogCapture.StackSourceOriginalException,
+                report.Attributes["backtrace.unity.stack_source"]);
+            Assert.AreEqual(
+                "System.NullReferenceException",
+                report.Attributes["backtrace.unity.original_exception.type"]);
         }
 
         [Test]

--- a/Tests/Runtime/ReportFilter/ReportFilterTypeTests.cs
+++ b/Tests/Runtime/ReportFilter/ReportFilterTypeTests.cs
@@ -325,16 +325,69 @@ namespace Backtrace.Unity.Tests.Runtime.ReportFilter
                 return type != ReportFilterType.UnhandledException;
             };
 
-            // in this situation to learn if we were able to continue processing report 
+            // in this situation to learn if we were able to continue processing report
             // we should check if before send event or reportFilter event was called
             BacktraceClient.Configuration.ReportFilterType = ReportFilterType.Exception;
             BacktraceClient.Send(new BacktraceUnhandledException(string.Empty, string.Empty));
 
-            
+
             Assert.IsTrue(reportFilterCalled);
             Assert.IsTrue(eventCalled);
 
             yield return null;
+        }
+
+        [Test]
+        public void TestUnityLogHandlerException_ShouldUseUnhandledExceptionFilterType()
+        {
+            var reportFilterType = ReportFilterType.None;
+            BacktraceClient.Configuration.UnityLogHandlerExceptionCapture =
+                BacktraceUnityLogHandlerExceptionCaptureMode.Enabled;
+            BacktraceClient.SkipReport = (ReportFilterType type, Exception e, string msg) =>
+            {
+                reportFilterType = type;
+                return true;
+            };
+            var exception = new InvalidOperationException("Validation exception");
+            Assert.IsTrue(
+                BacktraceClient.RecordUnityLogHandlerException(exception, null));
+            BacktraceClient.HandleUnityMessage(
+                "InvalidOperationException: Validation exception",
+                "ExampleClass.HandleException() (at Assets/ExampleClass.cs:42)",
+                LogType.Exception);
+            Assert.AreEqual(ReportFilterType.UnhandledException, reportFilterType);
+        }
+
+        [Test]
+        public void TestUnityCallbackExceptionWithoutLogHandler_ShouldUseUnhandledExceptionFilterType()
+        {
+            var reportFilterType = ReportFilterType.None;
+            BacktraceClient.SkipReport = (ReportFilterType type, Exception e, string msg) =>
+            {
+                reportFilterType = type;
+                return true;
+            };
+            BacktraceClient.HandleUnityMessage(
+                "NullReferenceException: Object reference not set to an instance of an object.",
+                "ExampleClass.Update() (at Assets/ExampleClass.cs:42)",
+                LogType.Exception);
+            Assert.AreEqual(ReportFilterType.UnhandledException, reportFilterType);
+        }
+
+        [UnityTest]
+        public IEnumerator TestExplicitSendException_ShouldRemainHandledException()
+        {
+            BacktraceData data = null;
+            BacktraceClient.BeforeSend = (BacktraceData reportData) =>
+            {
+                data = reportData;
+                return null;
+            };
+            BacktraceClient.Send(new InvalidOperationException("Handled exception"));
+            yield return WaitForFrame.Wait();
+            Assert.IsNotNull(data);
+            Assert.AreEqual("Exception", data.Attributes.Attributes["error.type"]);
+            Assert.IsFalse(data.Attributes.Attributes.ContainsKey("backtrace.unity.capture_path"));
         }
     }
 }


### PR DESCRIPTION
## Problem

Some managed Unity exception reports on iOS/macOS were being ingested as `error.type=Crash` when native Apple crash capture was enabled.

Affected payloads were managed C#/IL2CPP reports from `backtrace-unity` with `Backtrace.Unity.Model.BacktraceUnhandledException` annotations and managed stack frames, but their final attributes contained `error.type=Crash`.

## Root cause

Apple native crash capture seeds native reports with `error.type=Crash`, which is correct for PLCrashReporter/native crash payloads.

However, the native Apple client is also registered as a dynamic attribute provider. Managed report construction previously created `BacktraceData` from report attributes and then merged client/native dynamic attributes afterward. That merge order allowed native/client values to overwrite report-scoped values such as:

- `error.type`
- `error.message`
- `_mod_fingerprint`

This let native `error.type=Crash` overwrite managed Unity report classification.

## Fix

This PR preserves report-source classification by applying client/native attributes as defaults before constructing `BacktraceData`. Report-scoped attributes now win through the existing `BacktraceAttributes` merge path.

The PR also filters `error.type` out of iOS/macOS native dynamic attributes copied into managed reports as a defensive guard. Native crash reports are unaffected because native crash payloads still keep `error.type=Crash` in the native path.

## Classification contract

After this change:

- Explicit `BacktraceClient.Send(Exception)` reports remain `error.type=Exception`.
- Unity `LogType.Exception` callback reports remain `error.type=Unhandled exception`.
- Unity log-handler candidate reports remain Unity log reports; the log-handler wrapper is metadata recovery only and is not a handled/unhandled classifier.
- Native Apple crash reports remain `error.type=Crash`.
- ANR reports remain `error.type=Hang`.
- OOM reports remain `error.type=OOMException`.

## Tests

Added regression coverage for:

- native/client dynamic `error.type` not overriding managed `BacktraceUnhandledException`;
- native/client dynamic `error.type` not overriding explicit handled `BacktraceClient.Send(Exception)`;
- native/client dynamic attributes still being preserved when they do not collide with report-scoped attributes;
- Unity log-handler candidate reports remaining `Unhandled exception`;
- plain Unity callback reports remaining `Unhandled exception`;
- explicit `BacktraceClient.Send(Exception)` reports remaining `Exception`.

## Notes:

- The change restores the intended precedence model: client/native attributes are defaults, report attributes are authoritative. Customers that intentionally need to override `error.type` can still do so in `BeforeSend`, which runs after `BacktraceData` is constructed.

- Native Apple crash classification is preserved because the native crash path still sends `error.type=Crash`.

- Validated expected payload shapes / [Sample Reports](https://share.backtrace.io/api/share/UBdfCtlYkuGtlcELHpg3B1) :

  - Managed Unity exception with native crash capture enabled: no longer overwritten to `Crash`.
  - Explicit handled SDK send: `error.type=Exception`.
  - Unity log exception callback: `error.type=Unhandled exception`.
  - Native Apple crash: `error.type=Crash`.

ref: BT-6903