### PR TITLE
chore: fix failing unity tests on windows player builds

### DIFF
--- a/Runtime/Native/Windows/NativeClient.cs
+++ b/Runtime/Native/Windows/NativeClient.cs
@@ -424,6 +424,7 @@ namespace Backtrace.Unity.Runtime.Native.Windows
                         { SessionKey, BacktraceMetrics.ApplicationSessionKey }
                     };
 
+            bool removedLegacy = false;
             foreach (var legacyAttribute in legacyAttributes)
             {
                 string legacyAttributeValue = PlayerPrefs.GetString(legacyAttribute.Key, string.Empty);
@@ -431,7 +432,13 @@ namespace Backtrace.Unity.Runtime.Native.Windows
                 {
                     PlayerPrefs.DeleteKey(legacyAttribute.Key);
                     result[legacyAttribute.Value] = legacyAttributeValue;
+                    removedLegacy = true;
                 }
+            }
+
+            if (removedLegacy)
+            {
+                PlayerPrefs.Save();
             }
             return result;
         }

--- a/Runtime/Native/Windows/NativeClient.cs
+++ b/Runtime/Native/Windows/NativeClient.cs
@@ -364,7 +364,7 @@ namespace Backtrace.Unity.Runtime.Native.Windows
             // the reason behind this decision is to make sure user change in the configuration
             // won't leave any useless data
             var attributesJson = PlayerPrefs.GetString(ScopedAttributeListKey);
-            if (!HasScopedAttributesEmpty(attributesJson))
+            if (!HasScopedAttributes(attributesJson))
             {
                 return;
             }
@@ -392,7 +392,7 @@ namespace Backtrace.Unity.Runtime.Native.Windows
         {
             var result = new Dictionary<string, string>(StringComparer.Ordinal);
             var attributesJson = PlayerPrefs.GetString(ScopedAttributeListKey);
-            if (HasScopedAttributesEmpty(attributesJson))
+            if (HasScopedAttributes(attributesJson))
             {
                 ScopedAttributesContainer attributes;
 
@@ -455,7 +455,7 @@ namespace Backtrace.Unity.Runtime.Native.Windows
         {
             var keys = new HashSet<string>(StringComparer.Ordinal);
             var attributesJson = PlayerPrefs.GetString(ScopedAttributeListKey);
-            if (HasScopedAttributesEmpty(attributesJson))
+            if (HasScopedAttributes(attributesJson))
             {
                 try
                 {
@@ -582,7 +582,7 @@ namespace Backtrace.Unity.Runtime.Native.Windows
             PlayerPrefs.Save();
         }
 
-        private static bool HasScopedAttributesEmpty(string attributesJson)
+        private static bool HasScopedAttributes(string attributesJson)
         {
             return !(string.IsNullOrEmpty(attributesJson) || attributesJson == "{}");
         }

--- a/Runtime/Native/Windows/NativeClient.cs
+++ b/Runtime/Native/Windows/NativeClient.cs
@@ -390,34 +390,30 @@ namespace Backtrace.Unity.Runtime.Native.Windows
 
         internal static IDictionary<string, string> GetScopedAttributes()
         {
-            var attributesJson = PlayerPrefs.GetString(ScopedAttributeListKey);
-            if (!HasScopedAttributesEmpty(attributesJson))
-            {
-                return new Dictionary<string, string>();
-            }
-
             var result = new Dictionary<string, string>(StringComparer.Ordinal);
-            ScopedAttributesContainer attributes = null;
+            var attributesJson = PlayerPrefs.GetString(ScopedAttributeListKey);
+            if (HasScopedAttributesEmpty(attributesJson))
+            {
+                ScopedAttributesContainer attributes;
 
-            try
-            {
-                attributes = JsonUtility.FromJson<ScopedAttributesContainer>(attributesJson);
-            }
-            catch (Exception e)
-            {
-                Debug.LogWarning($"Backtrace Failed to parse scoped attributes at read: {e.Message}");
-                return result;
-            }
+                try
+                {
+                    attributes = JsonUtility.FromJson<ScopedAttributesContainer>(attributesJson);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogWarning($"Backtrace Failed to parse scoped attributes at read: {e.Message}");
+                    return result;
+                }
 
-            if (attributes?.Keys == null)
-            {
-                return result;
-            }
-
-            foreach (var attributeKey in attributes.Keys)
-            {
-                var value = PlayerPrefs.GetString(string.Format(ScopedAttributesPattern, attributeKey), string.Empty);
-                result[attributeKey] = value;
+                if (attributes?.Keys != null)
+                {
+                    foreach (var attributeKey in attributes.Keys)
+                    {
+                        var value = PlayerPrefs.GetString(string.Format(ScopedAttributesPattern, attributeKey), string.Empty);
+                        result[attributeKey] = value;
+                    }
+                }
             }
 
             // extend scoped attributes with legacy attributes stored by Backtrace-Unity library in previous versions

--- a/Tests/Runtime/BacktraceStackTraceTests.cs
+++ b/Tests/Runtime/BacktraceStackTraceTests.cs
@@ -331,6 +331,9 @@ namespace Backtrace.Unity.Tests.Runtime
         [Test]
         public void TestStackTraceCreation_AndroidException_ValidStackTraceObject()
         {
+#if !UNITY_ANDROID && !UNITY_EDITOR
+            Assert.Ignore("Android stack trace parsing is only compiled for Android and the Editor.");
+#endif
             var stackTrace = ConvertStackTraceToString(_anrStackTrace);
             var exception = new BacktraceUnhandledException(string.Empty, stackTrace);
             var backtraceStackTrace = new BacktraceStackTrace(exception);
@@ -348,6 +351,9 @@ namespace Backtrace.Unity.Tests.Runtime
         [Test]
         public void TestNativeStackTraceDetection_AndroidExceptionShouldSetFlag_NativeStackTraceIsSet()
         {
+#if !UNITY_ANDROID && !UNITY_EDITOR
+            Assert.Ignore("Android stack trace parsing is only compiled for Android and the Editor.");
+#endif
             var stackTrace = ConvertStackTraceToString(_anrStackTrace);
             var exception = new BacktraceUnhandledException(string.Empty, stackTrace);
             Assert.IsTrue(exception.NativeStackTrace);
@@ -366,6 +372,9 @@ namespace Backtrace.Unity.Tests.Runtime
         [Test]
         public void TestStackTraceCreation_AndroidMixModeCallStack_ValidStackTraceObject()
         {
+#if !UNITY_ANDROID && !UNITY_EDITOR
+            Assert.Ignore("Android stack trace parsing is only compiled for Android and the Editor.");
+#endif
             var stackTrace = ConvertStackTraceToString(_mixModeCallStack);
             var exception = new BacktraceUnhandledException(string.Empty, stackTrace);
             var backtraceStackTrace = new BacktraceStackTrace(exception);

--- a/Tests/Runtime/Client/BacktraceClientDisableTests.cs
+++ b/Tests/Runtime/Client/BacktraceClientDisableTests.cs
@@ -18,9 +18,19 @@ namespace Backtrace.Unity.Tests.Runtime.Client
             AfterSetup(false);
         }
 
+        // Skip in a Player build: DisableInEditor only disables the client in the Editor
+        private static void SkipWhenNotInEditor()
+        {
+            if (!Application.isEditor)
+            {
+                Assert.Ignore("DisableInEditor only applies in the Editor.");
+            }
+        }
+
         [Test]
         public void TestEditorDisabling_ShouldntSendData_ShouldntSendExceptionViaSendAPI()
         {
+            SkipWhenNotInEditor();
             var clientConfiguration = GetValidClientConfiguration();
             BacktraceClient.Configuration = clientConfiguration;
             BacktraceClient.Configuration.DisableInEditor = true;
@@ -42,6 +52,7 @@ namespace Backtrace.Unity.Tests.Runtime.Client
         [Test]
         public void TestEditorDisabling_ShouldntSendData_ShouldntSendReportViaSendAPI()
         {
+            SkipWhenNotInEditor();
             var clientConfiguration = GetValidClientConfiguration();
             BacktraceClient.Configuration = clientConfiguration;
             BacktraceClient.Configuration.DisableInEditor = true;
@@ -63,6 +74,7 @@ namespace Backtrace.Unity.Tests.Runtime.Client
         [Test]
         public void TestEditorDisabling_ShouldntSendData_ShouldntSendMessageViaSendAPI()
         {
+            SkipWhenNotInEditor();
             var clientConfiguration = GetValidClientConfiguration();
             BacktraceClient.Configuration = clientConfiguration;
             BacktraceClient.Configuration.DisableInEditor = true;
@@ -84,6 +96,7 @@ namespace Backtrace.Unity.Tests.Runtime.Client
         [Test]
         public void TestEditorDisabling_ShouldntSendData_ShouldntSendUnhandledException()
         {
+            SkipWhenNotInEditor();
             var clientConfiguration = GetValidClientConfiguration();
             BacktraceClient.Configuration = clientConfiguration;
             BacktraceClient.Configuration.DisableInEditor = true;

--- a/Tests/Runtime/Native/Windows/ScopedNativeAttributesTests.cs
+++ b/Tests/Runtime/Native/Windows/ScopedNativeAttributesTests.cs
@@ -14,8 +14,20 @@ namespace Backtrace.Unity.Tests.Runtime.Native.Windows
         private const string ScopedKeyList = "backtrace-scoped-attributes";
         private const string ScopedValuePattern = "bt-{0}";
 
-        [TearDown]
+        // PlayerPrefs persist between runs in a Player build, so clean before and after each test
+        [SetUp]
         public void Setup()
+        {
+            CleanState();
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            CleanState();
+        }
+
+        private void CleanState()
         {
             CleanLegacyAttributes();
             NativeClient.CleanScopedAttributes();


### PR DESCRIPTION
## Summary

Fixes tests that passed in the Editor but failed with Player, fixed a bug in the Windows native client which was causing mishandling of legacy attributes, guard a few tests that should only run in the Editor or Android.

## Changes

- `NativeClient`: `GetScopedAttributes` no longer returns early when there's no scoped list, so legacy attributes are still migrated on upgrade. Save PlayerPrefs after removing legacy keys.
- Renamed `HasScopedAttributesEmpty` to `HasScopedAttributes`, which returns true when attributes exist.
- `ScopedNativeAttributesTests`: clear PlayerPrefs in `[SetUp]` so tests don't inherit state from earlier Player runs.
- `BacktraceClientDisableTests`: skip the `DisableInEditor` tests in Player builds, should be Editor only.
- `BacktraceStackTraceTests`: skip the Android stack trace tests in Player builds, should be Android/Editor only