### PR TITLE
bugfix: fix potential thread-safety issue in BacktraceLogManager

### DIFF
--- a/Runtime/Model/BacktraceLogManager.cs
+++ b/Runtime/Model/BacktraceLogManager.cs
@@ -101,17 +101,18 @@ namespace Backtrace.Unity.Model
         /// <returns>Source code</returns>
         public string ToSourceCode()
         {
+            string[] logs;
             lock (lockObject)
             {
-                var stringBuilder = new StringBuilder();
-
-                var logs = LogQueue.ToArray();
-                foreach (var log in logs)
-                {
-                    stringBuilder.AppendLine(log);
-                }
-                return stringBuilder.ToString();
+                logs = LogQueue.ToArray();
             }
+
+            var stringBuilder = new StringBuilder();
+            foreach (var log in logs)
+            {
+                stringBuilder.AppendLine(log);
+            }
+            return stringBuilder.ToString();
         }
     }
 }

--- a/Runtime/Model/BacktraceLogManager.cs
+++ b/Runtime/Model/BacktraceLogManager.cs
@@ -101,14 +101,17 @@ namespace Backtrace.Unity.Model
         /// <returns>Source code</returns>
         public string ToSourceCode()
         {
-            var stringBuilder = new StringBuilder();
-
-            var logs = LogQueue.ToArray();
-            foreach (var log in logs)
+            lock (lockObject)
             {
-                stringBuilder.AppendLine(log);
+                var stringBuilder = new StringBuilder();
+
+                var logs = LogQueue.ToArray();
+                foreach (var log in logs)
+                {
+                    stringBuilder.AppendLine(log);
+                }
+                return stringBuilder.ToString();
             }
-            return stringBuilder.ToString();
         }
     }
 }


### PR DESCRIPTION
## Summary

`ToSourceCode()` reads the log queue without the lock that `Enqueue()`/`Dequeue()` use, so a concurrent log from a background thread could corrupt the read. This makes the manager thread-safe on its own instead of relying on the caller to lock.

## Changes

- `BacktraceLogManager`: Wrap the `LogQueue` read in `ToSourceCode()` with `lockObject`.

ref: BT-7318