### PR TITLE
Correct process-ABI reporting and contain native startup failures

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,35 @@ jobs:
           mkdir ${{ matrix.projectPath }}
           mv Editor Runtime Tests Android iOS Mac Windows package.json ${{ matrix.projectPath }}/
 
+      # The synthetic project has no saved scene, and game-ci then builds the untitled scene.
+      # Unity 2019.4 tolerates that but 2022.3+ fails with "Cannot build untitled scene", this gives the build a registered empty scene.
+      - name: Create CI build scene
+        run: |
+          mkdir -p ${{ matrix.projectPath }}/Assets/Scenes ${{ matrix.projectPath }}/ProjectSettings
+          printf '%%YAML 1.1\n%%TAG !u! tag:unity3d.com,2011:\n' > ${{ matrix.projectPath }}/Assets/Scenes/Empty.unity
+          cat > ${{ matrix.projectPath }}/Assets/Scenes/Empty.unity.meta <<'EOF'
+          fileFormatVersion: 2
+          guid: 9fc0d4010bbf28b4594072e72b8655ab
+          DefaultImporter:
+            externalObjects: {}
+            userData:
+            assetBundleName:
+            assetBundleVariant:
+          EOF
+          cat > ${{ matrix.projectPath }}/ProjectSettings/EditorBuildSettings.asset <<'EOF'
+          %YAML 1.1
+          %TAG !u! tag:unity3d.com,2011:
+          --- !u!1045 &1
+          EditorBuildSettings:
+            m_ObjectHideFlags: 0
+            serializedVersion: 2
+            m_Scenes:
+            - enabled: 1
+              path: Assets/Scenes/Empty.unity
+              guid: 9fc0d4010bbf28b4594072e72b8655ab
+            m_configObjects: {}
+          EOF
+
       - if: matrix.targetPlatform == 'Android'
         uses: jlumbroso/free-disk-space@v1.3.1
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,15 @@ jobs:
           - iOS
           - Android
           - WebGL
+        # The Android bridge touches native plugin loading, P/Invoke marshalling, and App Bundle packaging, Android players also build on modern Unity versions.
+        # Other platforms are unaffected and stay on the single baseline version.
+        include:
+          - projectPath: test-package
+            unityVersion: 2022.3.56f1
+            targetPlatform: Android
+          - projectPath: test-package
+            unityVersion: 6000.3.7f1
+            targetPlatform: Android
 
     steps:
       - name: Checkout Repo

--- a/Runtime/Model/Attributes/MachineAttributeProvider.cs
+++ b/Runtime/Model/Attributes/MachineAttributeProvider.cs
@@ -3,6 +3,9 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using UnityEngine;
+#if UNITY_ANDROID && !UNITY_EDITOR
+using Backtrace.Unity.Runtime.Native.Android;
+#endif
 
 namespace Backtrace.Unity.Model.Attributes
 {
@@ -63,17 +66,22 @@ namespace Backtrace.Unity.Model.Attributes
 
                     var deviceSdkVersion = version.GetStatic<int>("SDK_INT");
                     attributes["device.sdk"] = deviceSdkVersion.ToString();
-                    if(deviceSdkVersion >= 21) 
-                    {
-                        string[] supportedAbis = build.GetStatic<string[]>("SUPPORTED_ABIS");
-                        
-                        if (supportedAbis != null && supportedAbis.Length > 0)
-                        {
-                            attributes["device.abi"] =  supportedAbis[0];
-                        }
-                        
-                    }
                 }
+            }
+            // device.abi must be the ABI of THIS PROCESS, not the device-preferred SUPPORTED_ABIS[0]:
+            // a 32-bit Unity process on a 64-bit-capable device would otherwise report arm64-v8a while the native handler runs armeabi-v7a.
+            // The same helper drives native-library resolution, the report metadata and the resolved handler path always agree.
+            try
+            {
+                string processAbi = AndroidProcessAbi.Capture();
+                if (!string.IsNullOrEmpty(processAbi))
+                {
+                    attributes["device.abi"] = processAbi;
+                }
+            }
+            catch (Exception)
+            {
+                // ABI is optional report metadata; native setup performs its own contained resolution.
             }
             attributes["uname.fullname"] = Environment.OSVersion.Version.ToString();
 #else

--- a/Runtime/Native/Android/AndroidApplicationInfoSnapshot.cs
+++ b/Runtime/Native/Android/AndroidApplicationInfoSnapshot.cs
@@ -20,38 +20,78 @@ namespace Backtrace.Unity.Runtime.Native.Android
 
 #if UNITY_ANDROID
         /// <summary>
-        /// Populates the snapshot from the current application context.
-        /// Missing pieces (for example a host without a Unity activity, or splitNames below API 26) leave the corresponding fields null; the resolver treats every field as optional.
+        /// Populates the snapshot from the current application context. The whole operation is
+        /// fail-safe: a missing Unity activity (for example a Flutter host), an unavailable
+        /// context, or any JNI failure returns an empty snapshot instead of throwing, so an
+        /// application-metadata problem can never prevent the authoritative linker path from
+        /// being used. splitNames is read only on API 26+, where the field exists.
         /// </summary>
         internal static AndroidApplicationInfoSnapshot Capture()
         {
             var snapshot = new AndroidApplicationInfoSnapshot();
-            using (var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
+            try
             {
-                if (unityPlayer == null)
+                using (var unityPlayer = new AndroidJavaClass("com.unity3d.player.UnityPlayer"))
                 {
-                    return snapshot;
-                }
-                using (var activity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity"))
-                {
-                    if (activity == null)
+                    if (unityPlayer == null)
                     {
                         return snapshot;
                     }
-                    using (var context = activity.Call<AndroidJavaObject>("getApplicationContext"))
-                    using (var applicationInfo = context.Call<AndroidJavaObject>("getApplicationInfo"))
+                    using (var activity = unityPlayer.GetStatic<AndroidJavaObject>("currentActivity"))
                     {
-                        snapshot.SourceDir = TryGetString(applicationInfo, "sourceDir");
-                        snapshot.PublicSourceDir = TryGetString(applicationInfo, "publicSourceDir");
-                        snapshot.NativeLibraryDir = TryGetString(applicationInfo, "nativeLibraryDir");
-                        snapshot.SplitSourceDirs = TryGetStringArray(applicationInfo, "splitSourceDirs");
-                        snapshot.SplitPublicSourceDirs = TryGetStringArray(applicationInfo, "splitPublicSourceDirs");
-                        // splitNames exists only from API 26; on older platforms the field read throws.
-                        snapshot.SplitNames = TryGetStringArray(applicationInfo, "splitNames");
+                        if (activity == null)
+                        {
+                            return snapshot;
+                        }
+                        using (var context = activity.Call<AndroidJavaObject>("getApplicationContext"))
+                        {
+                            if (context == null)
+                            {
+                                return snapshot;
+                            }
+                            using (var applicationInfo = context.Call<AndroidJavaObject>("getApplicationInfo"))
+                            {
+                                if (applicationInfo == null)
+                                {
+                                    return snapshot;
+                                }
+                                snapshot.SourceDir = TryGetString(applicationInfo, "sourceDir");
+                                snapshot.PublicSourceDir = TryGetString(applicationInfo, "publicSourceDir");
+                                snapshot.NativeLibraryDir = TryGetString(applicationInfo, "nativeLibraryDir");
+                                snapshot.SplitSourceDirs = TryGetStringArray(applicationInfo, "splitSourceDirs");
+                                snapshot.SplitPublicSourceDirs =
+                                    TryGetStringArray(applicationInfo, "splitPublicSourceDirs");
+                                // API-level guard instead of relying on the caught NoSuchFieldError:
+                                // the field exists only from API 26.
+                                if (GetSdkVersion() >= 26)
+                                {
+                                    snapshot.SplitNames = TryGetStringArray(applicationInfo, "splitNames");
+                                }
+                            }
+                        }
                     }
                 }
             }
+            catch (System.Exception)
+            {
+                return snapshot;
+            }
             return snapshot;
+        }
+
+        private static int GetSdkVersion()
+        {
+            try
+            {
+                using (var version = new AndroidJavaClass("android.os.Build$VERSION"))
+                {
+                    return version.GetStatic<int>("SDK_INT");
+                }
+            }
+            catch (System.Exception)
+            {
+                return 0;
+            }
         }
 
         private static string TryGetString(AndroidJavaObject applicationInfo, string fieldName)

--- a/Runtime/Native/Android/AndroidNativeInterop.cs
+++ b/Runtime/Native/Android/AndroidNativeInterop.cs
@@ -1,0 +1,40 @@
+#if UNITY_ANDROID || UNITY_EDITOR
+using System;
+using System.Runtime.InteropServices;
+
+namespace Backtrace.Unity.Runtime.Native.Android
+{
+    /// <summary>
+    /// P/Invoke declarations for libbacktrace-native.so. Return types must match the native exports:
+    /// only InitializeJavaCrashHandler returns a value; AddAttribute,
+    /// DumpWithoutCrash, and Disable are void. Declaring a native void function as returning bool reads undefined register contents.
+    ///
+    /// This class compiles in the Editor so the EditMode signature tests can pin these declarations by reflection,
+    /// but the methods must only ever be INVOKED on an Android player, where the native library is loadable.
+    /// </summary>
+    internal static class AndroidNativeInterop
+    {
+        [DllImport("backtrace-native", EntryPoint = "InitializeJavaCrashHandler", CallingConvention = CallingConvention.Cdecl)]
+        [return: MarshalAs(UnmanagedType.I1)]
+        internal static extern bool InitializeJavaCrashHandler(
+            IntPtr submissionUrl,
+            IntPtr databasePath,
+            IntPtr classPath,
+            IntPtr keys,
+            IntPtr values,
+            IntPtr attachments,
+            IntPtr environmentVariables);
+
+        [DllImport("backtrace-native", EntryPoint = "AddAttribute", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void AddAttribute(IntPtr key, IntPtr value);
+
+        [DllImport("backtrace-native", EntryPoint = "DumpWithoutCrash", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void DumpWithoutCrash(
+            IntPtr message,
+            [MarshalAs(UnmanagedType.I1)] bool setMainThreadAsFaultingThread);
+
+        [DllImport("backtrace-native", EntryPoint = "Disable", CallingConvention = CallingConvention.Cdecl)]
+        internal static extern void Disable();
+    }
+}
+#endif

--- a/Runtime/Native/Android/AndroidNativeInterop.cs.meta
+++ b/Runtime/Native/Android/AndroidNativeInterop.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2deffffea006488eb443d880082eb7d6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Native/Android/AndroidNativeLibraryPathResolver.cs
+++ b/Runtime/Native/Android/AndroidNativeLibraryPathResolver.cs
@@ -82,6 +82,69 @@ namespace Backtrace.Unity.Runtime.Native.Android
             return baseApk + ApkLibrarySeparator + entry;
         }
 
+        /// <summary> 
+        /// Selects the native-library directory for the CURRENT PROCESS from extracted-library candidates (for example the directories under an APK-adjacent "lib" directory).
+        /// Enumeration order is never a selection policy: an exact ABI-mapped directory name wins
+        /// (arm64-v8a maps to "arm64" or "arm64-v8a", armeabi-v7a to "arm", "armeabi-v7a", or "armeabi", x86_64 and x86 exactly, x86 can never select x86_64);
+        /// without an exact match a single remaining candidate is a compatibility fallback, and anything ambiguous returns null so split/base-APK resolution decides instead.
+        /// </summary>
+        internal static string SelectNativeLibraryDirectory(string[] candidateDirectories, string processAbi)
+        {
+            if (candidateDirectories == null || candidateDirectories.Length == 0)
+            {
+                return null;
+            }
+
+            if (!string.IsNullOrEmpty(processAbi))
+            {
+                string[] acceptedNames = GetAbiDirectoryNames(processAbi);
+                foreach (string candidate in candidateDirectories)
+                {
+                    if (string.IsNullOrEmpty(candidate))
+                    {
+                        continue;
+                    }
+                    string name = NormalizeAbiToken(GetFileName(candidate.TrimEnd('/')));
+                    for (int index = 0; index < acceptedNames.Length; index++)
+                    {
+                        if (acceptedNames[index].Equals(name, StringComparison.Ordinal))
+                        {
+                            return candidate;
+                        }
+                    }
+                }
+            }
+
+            string single = null;
+            foreach (string candidate in candidateDirectories)
+            {
+                if (string.IsNullOrEmpty(candidate))
+                {
+                    continue;
+                }
+                if (single != null)
+                {
+                    return null;
+                }
+                single = candidate;
+            }
+            return single;
+        }
+
+        private static string[] GetAbiDirectoryNames(string processAbi)
+        {
+            string normalized = NormalizeAbiToken(processAbi);
+            if (normalized.Equals("arm64_v8a", StringComparison.Ordinal))
+            {
+                return new[] { "arm64", "arm64_v8a" };
+            }
+            if (normalized.Equals("armeabi_v7a", StringComparison.Ordinal))
+            {
+                return new[] { "arm", "armeabi_v7a", "armeabi" };
+            }
+            return new[] { normalized };
+        }
+
         /// <summary>
         /// Structural validation only. The path is deliberately NOT compared against an ABI inferred in C#:
         /// Android has already resolved which module this process loaded,

--- a/Runtime/Native/Android/NativeClient.cs
+++ b/Runtime/Native/Android/NativeClient.cs
@@ -23,27 +23,7 @@ namespace Backtrace.Unity.Runtime.Native.Android
     {
         private const string CallbackMethodName = "OnAnrDetected";
 
-        [DllImport("backtrace-native", EntryPoint = "InitializeJavaCrashHandler", CallingConvention = CallingConvention.Cdecl)]
-        [return: MarshalAs(UnmanagedType.I1)]
-        private static extern bool InitializeJavaCrashHandlerNative(
-            IntPtr submissionUrl,
-            IntPtr databasePath,
-            IntPtr classPath,
-            IntPtr keys,
-            IntPtr values,
-            IntPtr attachments,
-            IntPtr environmentVariables);
-
-        [DllImport("backtrace-native", EntryPoint = "AddAttribute", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void AddAttributeNative(IntPtr key, IntPtr value);
-
-        [DllImport("backtrace-native", EntryPoint = "DumpWithoutCrash", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void DumpWithoutCrashNative(
-            IntPtr message,
-            [MarshalAs(UnmanagedType.I1)] bool setMainThreadAsFaultingThread);
-
-        [DllImport("backtrace-native", EntryPoint = "Disable", CallingConvention = CallingConvention.Cdecl)]
-        private static extern void DisableNativeIntegrationNative();
+        // The P/Invoke declarations live in AndroidNativeInterop, which also compiles in the Editor and the EditMode signature tests can pin the corrected return types.
 
         /// <summary>
         /// Attribute maps - list of attribute maps that allows Backtrace-Unity to rename attributes 
@@ -171,24 +151,21 @@ namespace Backtrace.Unity.Runtime.Native.Android
         /// <summary>
         /// Guess native directory path based on the data path directory.
         /// The application-info snapshot can miss nativeLibraryDir when the activity is not available.
+        /// Filesystem enumeration order is not a valid ABI-selection policy,
+        /// the process ABI picks the directory;
+        /// an ambiguous layout returns no guess and resolution continues with split/base-APK metadata.
         /// </summary>
         /// <returns>Guessed path to lib directory</returns>
-        private string GuessNativeDirectoryPath()
+        private string GuessNativeDirectoryPath(string processAbi)
         {
             var sourceDirectory = Path.Combine(Path.GetDirectoryName(Application.dataPath), "lib");
             if (!Directory.Exists(sourceDirectory))
             {
                 return string.Empty;
             }
-            var libDirectory = Directory.GetDirectories(sourceDirectory);
-            if (libDirectory.Length == 0)
-            {
-                return string.Empty;
-            }
-            else
-            {
-                return libDirectory[0];
-            }
+            var libDirectories = Directory.GetDirectories(sourceDirectory);
+            return AndroidNativeLibraryPathResolver.SelectNativeLibraryDirectory(libDirectories, processAbi)
+                ?? string.Empty;
         }
 
         /// <summary>
@@ -302,7 +279,7 @@ namespace Backtrace.Unity.Runtime.Native.Android
             {
                 keyReference = AndroidJNI.NewStringUTF(key);
                 valueReference = AndroidJNI.NewStringUTF(value ?? string.Empty);
-                AddAttributeNative(keyReference, valueReference);
+                AndroidNativeInterop.AddAttribute(keyReference, valueReference);
             }
             finally
             {
@@ -321,7 +298,7 @@ namespace Backtrace.Unity.Runtime.Native.Android
             try
             {
                 messageReference = AndroidJNI.NewStringUTF(message ?? string.Empty);
-                DumpWithoutCrashNative(messageReference, setMainThreadAsFaultingThread);
+                AndroidNativeInterop.DumpWithoutCrash(messageReference, setMainThreadAsFaultingThread);
             }
             finally
             {
@@ -354,7 +331,7 @@ namespace Backtrace.Unity.Runtime.Native.Android
                 valuesRef = AndroidJNIHelper.ConvertToJNIArray(attributeValues ?? new string[0]);
                 attachmentsRef = AndroidJNIHelper.ConvertToJNIArray(attachments ?? new string[0]);
                 environmentRef = AndroidJNIHelper.ConvertToJNIArray(environmentVariables ?? new string[0]);
-                return InitializeJavaCrashHandlerNative(
+                return AndroidNativeInterop.InitializeJavaCrashHandler(
                     urlRef,
                     databaseRef,
                     classRef,
@@ -448,6 +425,11 @@ namespace Backtrace.Unity.Runtime.Native.Android
 
             var minidumpUrl = new BacktraceCredentials(_configuration.GetValidServerUrl()).GetMinidumpSubmissionUrl().ToString();
 
+            // The authoritative linker answer is queried FIRST:
+            // it must remain usable even when process-ABI detection or application metadata is unavailable,
+            // and both of those lookups are fully fail-safe (they return null/empty instead of throwing).
+            var loadedLibraryPath = AndroidLoadedLibraryPath.TryGet();
+
             // The ABI of THIS PROCESS (not the device-preferred ABI: a 32-bit process on a 64-bit device differs).
             // It is required only for the x86 policy and the split/base-APK path fallback,
             // an undetermined ABI must not disable capture when the linker path or an extracted library resolves, so the resolver receives null and decides.
@@ -466,11 +448,10 @@ namespace Backtrace.Unity.Runtime.Native.Android
                 // Legacy discovery for hosts without a Unity activity.
                 // An empty native-library directory no longer disables capture:
                 // the linker-reported path or split metadata can still resolve the handler.
-                applicationInfo.NativeLibraryDir = GuessNativeDirectoryPath();
+                applicationInfo.NativeLibraryDir = GuessNativeDirectoryPath(processAbi);
             }
 
             // Resolution order: linker-reported path, extracted library, installed ABI split, base APK without opening an APK archive.
-            var loadedLibraryPath = AndroidLoadedLibraryPath.TryGet();
             var handlerPath = AndroidNativeLibraryPathResolver.Resolve(
                 applicationInfo,
                 loadedLibraryPath,
@@ -648,19 +629,46 @@ namespace Backtrace.Unity.Runtime.Native.Android
                                 if (!reported)
                                 {
                                     OnAnrDetection();
-                                    reported = true;
                                     if (!attached)
                                     {
-                                        // A transient early attach failure (JVM resource pressure) must not permanently disable hang dumps.
+                                        // A transient early attach failure (JVM resource pressure) must not permanently disable hang dumps;
+                                        // reported stays false so the next iteration retries this hang.
                                         attached = AndroidJNI.AttachCurrentThread() == 0;
                                     }
                                     if (attached)
                                     {
-                                        // set temporary attribute to "Hang"
-                                        SetNativeAttribute(ErrorTypeAttribute, HangType);
-                                        SendNativeDump(AnrMessage, true);
-                                        // update error.type attribute in case when crash happen
-                                        SetNativeAttribute(ErrorTypeAttribute, CrashType);
+                                        reported = true;
+                                        // The temporary Hang classification must be restored to Crash even when the dump fails,
+                                        // or a later native crash would be misclassified as a hang.
+                                        bool hangTypeApplied = false;
+                                        try
+                                        {
+                                            SetNativeAttribute(ErrorTypeAttribute, HangType);
+                                            hangTypeApplied = true;
+                                            SendNativeDump(AnrMessage, true);
+                                        }
+                                        catch (Exception exception)
+                                        {
+                                            Debug.LogWarning(
+                                                "BT_UNITY_ANDROID_NATIVE_DUMP_FAILURE: Failure type: "
+                                                    + FailureType(exception));
+                                        }
+                                        finally
+                                        {
+                                            if (hangTypeApplied)
+                                            {
+                                                try
+                                                {
+                                                    SetNativeAttribute(ErrorTypeAttribute, CrashType);
+                                                }
+                                                catch (Exception exception)
+                                                {
+                                                    Debug.LogWarning(
+                                                        "BT_UNITY_ANDROID_NATIVE_ATTRIBUTE_FAILURE: Failure type: "
+                                                            + FailureType(exception));
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             }
@@ -727,7 +735,7 @@ namespace Backtrace.Unity.Runtime.Native.Android
             {
                 if (CaptureNativeCrashes)
                 {
-                    DisableNativeIntegrationNative();
+                    AndroidNativeInterop.Disable();
                 }
             }
             catch (Exception exception)

--- a/Tests/Runtime/Native/Android/AndroidNativeInteropSignatureTests.cs
+++ b/Tests/Runtime/Native/Android/AndroidNativeInteropSignatureTests.cs
@@ -1,30 +1,30 @@
-#if UNITY_ANDROID
+#if UNITY_ANDROID || UNITY_EDITOR
 using System;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
+using Backtrace.Unity.Runtime.Native.Android;
 using NUnit.Framework;
 
 namespace Backtrace.Unity.Tests.Runtime
 {
     /// <summary>
     /// The native exports are: InitializeJavaCrashHandler -> bool; AddAttribute, DumpWithoutCrash, and Disable -> void.
-    /// A P/Invoke declaration that disagrees reads undefined register contents, so the private declarations are pinned by reflection.
-    /// Compiled only for the Android build target, where the Android NativeClient exists.
+    /// A P/Invoke declaration that disagrees reads undefined register contents, so the declarations are pinned by reflection.
+    /// AndroidNativeInterop compiles in the Editor (without ever being invoked there)
+    /// This suite executes in the in-editor PlayMode CI lane on every PR instead of requiring an Android player.
+    /// (It lives in the Backtrace.Unity.Tests.Runtime assembly, which Unity classifies as a PlayMode test assembly; the editmode lane compiles it but does not run it.)
     /// </summary>
     public class AndroidNativeInteropSignatureTests
     {
         private static MethodInfo FindPInvoke(string entryPoint)
         {
-            var nativeClient = typeof(Backtrace.Unity.BacktraceClient).Assembly
-                .GetType("Backtrace.Unity.Runtime.Native.Android.NativeClient");
-            Assert.IsNotNull(nativeClient, "Android NativeClient type must exist");
-
-            var method = nativeClient
-                .GetMethods(BindingFlags.NonPublic | BindingFlags.Static)
+            var method = typeof(AndroidNativeInterop)
+                .GetMethods(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Static)
                 .SingleOrDefault(candidate =>
                 {
-                    var import = candidate.GetCustomAttributes(typeof(System.Runtime.InteropServices.DllImportAttribute), false)
-                        .Cast<System.Runtime.InteropServices.DllImportAttribute>()
+                    var import = candidate.GetCustomAttributes(typeof(DllImportAttribute), false)
+                        .Cast<DllImportAttribute>()
                         .FirstOrDefault();
                     return import != null && import.EntryPoint == entryPoint;
                 });
@@ -35,7 +35,15 @@ namespace Backtrace.Unity.Tests.Runtime
         [Test]
         public void InitializeJavaCrashHandlerReturnsBool()
         {
-            Assert.AreEqual(typeof(bool), FindPInvoke("InitializeJavaCrashHandler").ReturnType);
+            var method = FindPInvoke("InitializeJavaCrashHandler");
+            Assert.AreEqual(typeof(bool), method.ReturnType);
+            // Native C++ bool must marshal as one byte; the default marshalling is four bytes.
+            var marshal = method.ReturnParameter
+                .GetCustomAttributes(typeof(MarshalAsAttribute), false)
+                .Cast<MarshalAsAttribute>()
+                .FirstOrDefault();
+            Assert.IsNotNull(marshal, "bool return must declare explicit marshalling");
+            Assert.AreEqual(UnmanagedType.I1, marshal.Value);
         }
 
         [Test]
@@ -54,6 +62,19 @@ namespace Backtrace.Unity.Tests.Runtime
         public void DisableReturnsVoid()
         {
             Assert.AreEqual(typeof(void), FindPInvoke("Disable").ReturnType);
+        }
+
+        [Test]
+        public void AllDeclarationsUseCdecl()
+        {
+            foreach (var entryPoint in new[] { "InitializeJavaCrashHandler", "AddAttribute", "DumpWithoutCrash", "Disable" })
+            {
+                var import = FindPInvoke(entryPoint)
+                    .GetCustomAttributes(typeof(DllImportAttribute), false)
+                    .Cast<DllImportAttribute>()
+                    .First();
+                Assert.AreEqual(CallingConvention.Cdecl, import.CallingConvention, entryPoint);
+            }
         }
     }
 }

--- a/Tests/Runtime/Native/Android/AndroidNativeLibraryPathResolverTests.cs
+++ b/Tests/Runtime/Native/Android/AndroidNativeLibraryPathResolverTests.cs
@@ -270,6 +270,58 @@ namespace Backtrace.Unity.Tests.Runtime
         }
 
         [Test]
+        public void DirectoryGuessSelectsArm64DirectoryForArm64Process()
+        {
+            var selected = AndroidNativeLibraryPathResolver.SelectNativeLibraryDirectory(
+                new[] { "/data/app/example/lib/arm", "/data/app/example/lib/arm64" }, "arm64-v8a");
+
+            Assert.AreEqual("/data/app/example/lib/arm64", selected);
+        }
+
+        [Test]
+        public void DirectoryGuessSelectsArmDirectoryForArmV7Process()
+        {
+            var selected = AndroidNativeLibraryPathResolver.SelectNativeLibraryDirectory(
+                new[] { "/data/app/example/lib/arm64", "/data/app/example/lib/arm" }, "armeabi-v7a");
+
+            Assert.AreEqual("/data/app/example/lib/arm", selected);
+        }
+
+        [Test]
+        public void DirectoryGuessNeverSelectsX8664ForX86Process()
+        {
+            var selected = AndroidNativeLibraryPathResolver.SelectNativeLibraryDirectory(
+                new[] { "/data/app/example/lib/x86_64", "/data/app/example/lib/other" }, "x86");
+
+            // No exact match and more than one candidate: no guess, resolution continues.
+            Assert.IsNull(selected);
+        }
+
+        [Test]
+        public void DirectoryGuessAmbiguousWithoutExactMatchReturnsNoGuess()
+        {
+            var selected = AndroidNativeLibraryPathResolver.SelectNativeLibraryDirectory(
+                new[] { "/data/app/example/lib/a", "/data/app/example/lib/b" }, "arm64-v8a");
+
+            Assert.IsNull(selected);
+        }
+
+        [Test]
+        public void DirectoryGuessSingleCandidateRemainsACompatibilityFallback()
+        {
+            var selected = AndroidNativeLibraryPathResolver.SelectNativeLibraryDirectory(
+                new[] { "/data/app/example/lib/somedir" }, "arm64-v8a");
+
+            Assert.AreEqual("/data/app/example/lib/somedir", selected);
+
+            // Even with an undetermined ABI, one unique directory is still usable.
+            Assert.AreEqual(
+                "/data/app/example/lib/somedir",
+                AndroidNativeLibraryPathResolver.SelectNativeLibraryDirectory(
+                    new[] { "/data/app/example/lib/somedir" }, null));
+        }
+
+        [Test]
         public void MissingAbiFailsOnlyWhenTheFallbackNeedsIt()
         {
             var loaded = "/data/app/example/lib/arm64/" + Library;


### PR DESCRIPTION
## Changes

- `device.abi` now reports the ABI of the running process through the same helper that drives native-library resolution. Previously `SUPPORTED_ABIS[0]` could record `arm64-v8a` for a 32-bit process running `armeabi-v7a`.
- The linker path is queried before any fallible lookup, and application-metadata capture is fully fail-safe, a context or JNI failure can no longer disable native capture when the linker already has the answer. `splitNames` is read only on API 26+.
- The extracted-library directory fallback selects by exact ABI-mapped name instead of filesystem enumeration order; ambiguity returns no guess and split/base-APK resolution decides.
- The ANR watchdog marks a hang reported only after the JVM attach succeeds (a failed attach retries on the next iteration) and always restores `error.type` from `Hang` to `Crash` in a `finally` block.
- P/Invoke declarations moved to an Editor-compilable `AndroidNativeInterop` class, so the signature tests (return types, one-byte bool marshalling, `Cdecl`) now execute in CI on every PR instead of never running.
- Android player builds added for Unity 2022.3 and 6000.3 alongside 2019.4. The synthetic CI project gets one registered empty scene: game-ci otherwise builds the untitled scene, which Unity 2019.4 tolerates but 2022.3+ rejects with "Cannot build untitled scene" (exit code 103).

ref: BT-7491
ref: BT-7492
ref: BT-7493
ref: BT-7494