### PR TITLE
Improve Android native crash startup and lifecycle reliability

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
 
   test:
     needs: validate-macos-framework-layout
-    name: Run Build for ${{ matrix.unityVersion }} ${{ matrix.unityVersion }}
+    name: Run Build for ${{ matrix.targetPlatform }} on Unity ${{ matrix.unityVersion }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -102,6 +102,8 @@ jobs:
           - projectPath: test-package
             unityVersion: 6000.3.7f1
             targetPlatform: Android
+            androidExportType: androidAppBundle
+            configureIl2Cpp: true
 
     steps:
       - name: Checkout Repo
@@ -113,6 +115,18 @@ jobs:
         run: |
           mkdir ${{ matrix.projectPath }}
           mv Editor Runtime Tests Android iOS Mac Windows package.json ${{ matrix.projectPath }}/
+
+      # Install only the SDK sources and plugins required by Android so the player build
+      # compiles the SDK with UNITY_ANDROID and packages its native libraries.
+      - name: Install SDK in Android project
+        if: matrix.targetPlatform == 'Android'
+        run: |
+          mkdir -p ${{ matrix.projectPath }}/Assets/Plugins/backtrace-unity
+          mv \
+            ${{ matrix.projectPath }}/Editor \
+            ${{ matrix.projectPath }}/Runtime \
+            ${{ matrix.projectPath }}/Android \
+            ${{ matrix.projectPath }}/Assets/Plugins/backtrace-unity/
 
       # The synthetic project has no saved scene, and game-ci then builds the untitled scene.
       # Unity 2019.4 tolerates that but 2022.3+ fails with "Cannot build untitled scene", this gives the build a registered empty scene.
@@ -143,6 +157,28 @@ jobs:
             m_configObjects: {}
           EOF
 
+      # Exercise the Android bridge in the modern packaging configuration without
+      # requiring a release keystore or a device-side deployment.
+      - name: Configure Android IL2CPP App Bundle build
+        if: matrix.configureIl2Cpp == true
+        run: |
+          mkdir -p ${{ matrix.projectPath }}/Assets/Editor
+          cat > ${{ matrix.projectPath }}/Assets/Editor/BacktraceCiAndroidSettings.cs <<'EOF'
+          using UnityEditor;
+
+          [InitializeOnLoad]
+          internal static class BacktraceCiAndroidSettings
+          {
+              static BacktraceCiAndroidSettings()
+              {
+                  PlayerSettings.SetScriptingBackend(
+                      BuildTargetGroup.Android,
+                      ScriptingImplementation.IL2CPP);
+                  PlayerSettings.Android.targetArchitectures = AndroidArchitecture.ARM64;
+              }
+          }
+          EOF
+
       - if: matrix.targetPlatform == 'Android'
         uses: jlumbroso/free-disk-space@v1.3.1
 
@@ -156,5 +192,19 @@ jobs:
           unityVersion: ${{ matrix.unityVersion }}
           targetPlatform: ${{ matrix.targetPlatform }}
           projectPath: ${{ matrix.projectPath }}/
+          androidExportType: ${{ matrix.androidExportType || 'androidPackage' }}
           allowDirtyBuild: true
-          
+
+      - name: Validate Android IL2CPP App Bundle contents
+        if: matrix.configureIl2Cpp == true
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -d '' app_bundles < <(find build -type f -name '*.aab' -print0)
+          test "${#app_bundles[@]}" -eq 1
+
+          entries="$RUNNER_TEMP/backtrace-aab-entries.txt"
+          unzip -Z1 "${app_bundles[0]}" > "$entries"
+          grep -Eq '(^|/)lib/arm64-v8a/libil2cpp\.so$' "$entries"
+          grep -Eq '(^|/)lib/arm64-v8a/libbacktrace-native\.so$' "$entries"

--- a/Runtime/Native/Android/AndroidAnrThreadLifecycle.cs
+++ b/Runtime/Native/Android/AndroidAnrThreadLifecycle.cs
@@ -1,0 +1,123 @@
+#if UNITY_ANDROID || UNITY_EDITOR
+using System;
+
+namespace Backtrace.Unity.Runtime.Native.Android
+{
+    /// <summary>
+    /// Contains the JNI attach/detach lifecycle for the Unity-created ANR worker.
+    /// The delegates keep the policy testable in the Editor without invoking Android JNI.
+    /// </summary>
+    internal static class AndroidAnrThreadLifecycle
+    {
+        internal const string ThreadFailureCode = "BT_UNITY_ANDROID_ANR_THREAD_FAILURE";
+        internal const string DetachFailureCode = "BT_UNITY_ANDROID_JNI_DETACH_FAILURE";
+        internal const string NativeDumpFailureCode = "BT_UNITY_ANDROID_NATIVE_DUMP_FAILURE";
+        internal const string NativeAttributeFailureCode = "BT_UNITY_ANDROID_NATIVE_ATTRIBUTE_FAILURE";
+
+        internal static void Run(
+            Func<int> attachCurrentThread,
+            Action<Func<bool>> runWatchdog,
+            Action detachCurrentThread,
+            Action<string> logWarning)
+        {
+            bool attached = false;
+            Func<bool> tryAttach = () =>
+            {
+                if (!attached)
+                {
+                    attached = attachCurrentThread() == 0;
+                }
+                return attached;
+            };
+
+            try
+            {
+                tryAttach();
+                runWatchdog(tryAttach);
+            }
+            catch (Exception exception)
+            {
+                LogFailure(ThreadFailureCode, exception, logWarning);
+            }
+            finally
+            {
+                if (attached)
+                {
+                    try
+                    {
+                        detachCurrentThread();
+                    }
+                    catch (Exception exception)
+                    {
+                        LogFailure(DetachFailureCode, exception, logWarning);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Applies the temporary Hang classification, sends the native dump, and always attempts to restore Crash.
+        /// The Hang write can succeed natively and then throw during JNI local-reference cleanup, restoration cannot depend on the call returning normally.
+        /// </summary>
+        internal static void CaptureNativeDump(
+            Action setHangType,
+            Action sendDump,
+            Action restoreCrashType,
+            Action<string> logWarning)
+        {
+            try
+            {
+                bool hangTypeApplied = false;
+                try
+                {
+                    setHangType();
+                    hangTypeApplied = true;
+                }
+                catch (Exception exception)
+                {
+                    LogFailure(NativeAttributeFailureCode, exception, logWarning);
+                }
+
+                if (hangTypeApplied)
+                {
+                    try
+                    {
+                        sendDump();
+                    }
+                    catch (Exception exception)
+                    {
+                        LogFailure(NativeDumpFailureCode, exception, logWarning);
+                    }
+                }
+            }
+            finally
+            {
+                try
+                {
+                    restoreCrashType();
+                }
+                catch (Exception exception)
+                {
+                    LogFailure(NativeAttributeFailureCode, exception, logWarning);
+                }
+            }
+        }
+
+        private static void LogFailure(string code, Exception exception, Action<string> logWarning)
+        {
+            var failureType = exception == null ? "unknown" : exception.GetType().FullName;
+            try
+            {
+                if (logWarning != null)
+                {
+                    logWarning(code + ": Failure type: " + failureType);
+                }
+            }
+            catch (Exception)
+            {
+                // Diagnostics must never allow an optional ANR worker failure to escape.
+            }
+        }
+    }
+}
+#endif

--- a/Runtime/Native/Android/AndroidAnrThreadLifecycle.cs.meta
+++ b/Runtime/Native/Android/AndroidAnrThreadLifecycle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8d0f6ad1b2e94cfa8622c51a8b311302
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Native/Android/AndroidCrashHandlerEnvironment.cs
+++ b/Runtime/Native/Android/AndroidCrashHandlerEnvironment.cs
@@ -18,6 +18,48 @@ namespace Backtrace.Unity.Runtime.Native.Android
         internal const string CrashHandlerVariable = "BACKTRACE_UNITY_CRASH_HANDLER";
 
         /// <summary>
+        /// Builds optional native-library search hints without allowing path or JNI failures to block startup.
+        /// BACKTRACE_UNITY_CRASH_HANDLER carries the resolved handler path;
+        /// these entries only enrich the child process environment.
+        /// </summary>
+        internal static string[] BuildLibrarySearchPaths(
+            string nativeLibraryDir,
+            Func<string, string> getParentDirectory,
+            Func<string> getSystemLibraryPath)
+        {
+            var searchPaths = new List<string>();
+            if (!string.IsNullOrEmpty(nativeLibraryDir))
+            {
+                searchPaths.Add(nativeLibraryDir);
+                TryAddSearchPath(
+                    searchPaths,
+                    () => getParentDirectory == null ? null : getParentDirectory(nativeLibraryDir));
+            }
+
+            TryAddSearchPath(
+                searchPaths,
+                () => getSystemLibraryPath == null ? null : getSystemLibraryPath());
+            searchPaths.Add("/data/local");
+            return searchPaths.ToArray();
+        }
+
+        private static void TryAddSearchPath(List<string> searchPaths, Func<string> getPath)
+        {
+            try
+            {
+                string path = getPath();
+                if (!string.IsNullOrEmpty(path))
+                {
+                    searchPaths.Add(path);
+                }
+            }
+            catch (Exception)
+            {
+                // Optional enrichment only. The resolved handler path remains authoritative.
+            }
+        }
+
+        /// <summary>
         /// CLASSPATH must remain the base APK containing the Java crash-handler classes;
         /// the native handler path may point at an ABI split.
         /// </summary>

--- a/Runtime/Native/Android/AndroidNativeDisableLifecycle.cs
+++ b/Runtime/Native/Android/AndroidNativeDisableLifecycle.cs
@@ -1,0 +1,70 @@
+#if UNITY_ANDROID || UNITY_EDITOR
+using System;
+
+namespace Backtrace.Unity.Runtime.Native.Android
+{
+    /// <summary>
+    /// Runs every Android native cleanup stage independently,
+    /// optional JNI failure cannot skip the remaining shutdown work or escape to the host game.
+    /// </summary>
+    internal static class AndroidNativeDisableLifecycle
+    {
+        internal const string AnrStopFailureCode = "BT_UNITY_ANDROID_ANR_STOP_FAILURE";
+        internal const string NativeDisableFailureCode = "BT_UNITY_ANDROID_NATIVE_DISABLE_FAILURE";
+        internal const string AnrWatcherStopFailureCode = "BT_UNITY_ANDROID_ANR_WATCHER_STOP_FAILURE";
+        internal const string AnrWatcherDisposeFailureCode = "BT_UNITY_ANDROID_ANR_WATCHER_DISPOSE_FAILURE";
+        internal const string UnhandledWatcherStopFailureCode = "BT_UNITY_ANDROID_UNHANDLED_WATCHER_STOP_FAILURE";
+        internal const string UnhandledWatcherDisposeFailureCode = "BT_UNITY_ANDROID_UNHANDLED_WATCHER_DISPOSE_FAILURE";
+
+        internal static void Run(
+            Action stopAnrThread,
+            Action disableNativeIntegration,
+            Action stopAnrWatcher,
+            Action disposeAnrWatcher,
+            Action stopUnhandledWatcher,
+            Action disposeUnhandledWatcher,
+            Action<string> logWarning)
+        {
+            RunStep(stopAnrThread, AnrStopFailureCode, logWarning);
+            RunStep(disableNativeIntegration, NativeDisableFailureCode, logWarning);
+            RunStep(stopAnrWatcher, AnrWatcherStopFailureCode, logWarning);
+            RunStep(disposeAnrWatcher, AnrWatcherDisposeFailureCode, logWarning);
+            RunStep(stopUnhandledWatcher, UnhandledWatcherStopFailureCode, logWarning);
+            RunStep(disposeUnhandledWatcher, UnhandledWatcherDisposeFailureCode, logWarning);
+        }
+
+        private static void RunStep(Action cleanup, string failureCode, Action<string> logWarning)
+        {
+            if (cleanup == null)
+            {
+                return;
+            }
+
+            try
+            {
+                cleanup();
+            }
+            catch (Exception exception)
+            {
+                LogFailure(failureCode, exception, logWarning);
+            }
+        }
+
+        private static void LogFailure(string code, Exception exception, Action<string> logWarning)
+        {
+            var failureType = exception == null ? "unknown" : exception.GetType().FullName;
+            try
+            {
+                if (logWarning != null)
+                {
+                    logWarning(code + ": Failure type: " + failureType);
+                }
+            }
+            catch (Exception)
+            {
+                // Cleanup diagnostics are optional and must not interrupt shutdown.
+            }
+        }
+    }
+}
+#endif

--- a/Runtime/Native/Android/AndroidNativeDisableLifecycle.cs.meta
+++ b/Runtime/Native/Android/AndroidNativeDisableLifecycle.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 46fa861a78334effa8ddcfb844320259
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Native/Android/AndroidNativeInitialization.cs
+++ b/Runtime/Native/Android/AndroidNativeInitialization.cs
@@ -1,0 +1,118 @@
+#if UNITY_ANDROID || UNITY_EDITOR
+using System;
+
+namespace Backtrace.Unity.Runtime.Native.Android
+{
+    /// <summary>
+    /// Coordinates native-backend activation and the managed setup that follows it.
+    /// The activation callback is invoked before JNI cleanup,
+    /// a cleanup failure after a successful native initialization still rolls the backend back.
+    /// </summary>
+    internal static class AndroidNativeInitialization
+    {
+        internal static bool Execute(
+            Func<Action, bool> initialize,
+            Action completeSetup,
+            Action rollback,
+            Action<Exception> reportRollbackFailure)
+        {
+            if (initialize == null)
+            {
+                throw new ArgumentNullException("initialize");
+            }
+            if (completeSetup == null)
+            {
+                throw new ArgumentNullException("completeSetup");
+            }
+            if (rollback == null)
+            {
+                throw new ArgumentNullException("rollback");
+            }
+
+            bool backendActive = false;
+            try
+            {
+                bool initialized = initialize(() => backendActive = true);
+                if (!initialized)
+                {
+                    return false;
+                }
+
+                // Keep the transaction safe even if an initializer forgets to invoke the early activation callback after returning true.
+                backendActive = true;
+                completeSetup();
+                return true;
+            }
+            catch
+            {
+                if (backendActive)
+                {
+                    try
+                    {
+                        rollback();
+                    }
+                    catch (Exception rollbackFailure)
+                    {
+                        // Rollback is best-effort. Preserve the setup exception, which is the actionable failure, while still allowing a contained diagnostic.
+                        if (reportRollbackFailure != null)
+                        {
+                            try
+                            {
+                                reportRollbackFailure(rollbackFailure);
+                            }
+                            catch (Exception)
+                            {
+                                // Diagnostics must never replace the setup failure.
+                            }
+                        }
+                    }
+                }
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Deletes every non-zero JNI local reference in the supplied order.
+        /// A failed deletion does not prevent later references from being released;
+        /// the first failure is rethrown after all cleanup attempts so native setup can be rolled back.
+        /// </summary>
+        internal static void DeleteLocalReferences(
+            Action<IntPtr> deleteLocalReference,
+            params IntPtr[] references)
+        {
+            if (deleteLocalReference == null)
+            {
+                throw new ArgumentNullException("deleteLocalReference");
+            }
+
+            Exception firstFailure = null;
+            if (references != null)
+            {
+                foreach (IntPtr reference in references)
+                {
+                    if (reference == IntPtr.Zero)
+                    {
+                        continue;
+                    }
+                    try
+                    {
+                        deleteLocalReference(reference);
+                    }
+                    catch (Exception exception)
+                    {
+                        if (firstFailure == null)
+                        {
+                            firstFailure = exception;
+                        }
+                    }
+                }
+            }
+
+            if (firstFailure != null)
+            {
+                throw firstFailure;
+            }
+        }
+    }
+}
+#endif

--- a/Runtime/Native/Android/AndroidNativeInitialization.cs.meta
+++ b/Runtime/Native/Android/AndroidNativeInitialization.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a94b15d34e7342b98cc6e9f5c61462aa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Runtime/Native/Android/AndroidNativeLibraryPathResolver.cs
+++ b/Runtime/Native/Android/AndroidNativeLibraryPathResolver.cs
@@ -82,11 +82,50 @@ namespace Backtrace.Unity.Runtime.Native.Android
             return baseApk + ApkLibrarySeparator + entry;
         }
 
+        /// <summary>
+        /// Best-effort compatibility lookup for hosts where ApplicationInfo.nativeLibraryDir is unavailable.
+        /// Directory discovery is optional enrichment:
+        /// filesystem or path failures return null so a linker-reported path or APK metadata can still resolve.
+        /// </summary>
+        internal static string TryGuessNativeLibraryDirectory(
+            string applicationDataPath,
+            string processAbi,
+            Func<string, bool> directoryExists,
+            Func<string, string[]> getDirectories)
+        {
+            try
+            {
+                if (directoryExists == null || getDirectories == null)
+                {
+                    return null;
+                }
+
+                string applicationDirectory = Path.GetDirectoryName(applicationDataPath);
+                if (string.IsNullOrEmpty(applicationDirectory))
+                {
+                    return null;
+                }
+
+                string sourceDirectory = Path.Combine(applicationDirectory, "lib");
+                if (!directoryExists(sourceDirectory))
+                {
+                    return null;
+                }
+
+                return SelectNativeLibraryDirectory(getDirectories(sourceDirectory), processAbi);
+            }
+            catch (Exception)
+            {
+                return null;
+            }
+        }
+
         /// <summary> 
         /// Selects the native-library directory for the CURRENT PROCESS from extracted-library candidates (for example the directories under an APK-adjacent "lib" directory).
-        /// Enumeration order is never a selection policy: an exact ABI-mapped directory name wins
-        /// (arm64-v8a maps to "arm64" or "arm64-v8a", armeabi-v7a to "arm", "armeabi-v7a", or "armeabi", x86_64 and x86 exactly, x86 can never select x86_64);
-        /// without an exact match a single remaining candidate is a compatibility fallback, and anything ambiguous returns null so split/base-APK resolution decides instead.
+        /// Enumeration order is never a selection policy: when the process ABI is known, only an exact ABI-mapped directory name is accepted
+        /// (arm64-v8a maps to "arm64" or "arm64-v8a", armeabi-v7a to "arm", "armeabi-v7a", or "armeabi", x86_64 and x86 exactly, x86 can never select x86_64).
+        /// Multiple distinct exact matches are ambiguous and return null instead of selecting whichever directory was enumerated first.
+        /// A single remaining candidate is a compatibility fallback only when the process ABI is unknown; anything else returns null so split/base-APK resolution decides instead.
         /// </summary>
         internal static string SelectNativeLibraryDirectory(string[] candidateDirectories, string processAbi)
         {
@@ -98,6 +137,7 @@ namespace Backtrace.Unity.Runtime.Native.Android
             if (!string.IsNullOrEmpty(processAbi))
             {
                 string[] acceptedNames = GetAbiDirectoryNames(processAbi);
+                string exactMatch = null;
                 foreach (string candidate in candidateDirectories)
                 {
                     if (string.IsNullOrEmpty(candidate))
@@ -109,10 +149,19 @@ namespace Backtrace.Unity.Runtime.Native.Android
                     {
                         if (acceptedNames[index].Equals(name, StringComparison.Ordinal))
                         {
-                            return candidate;
+                            if (exactMatch != null
+                                && !exactMatch.Equals(candidate, StringComparison.Ordinal))
+                            {
+                                return null;
+                            }
+
+                            exactMatch = candidate;
+                            break;
                         }
                     }
                 }
+
+                return exactMatch;
             }
 
             string single = null;

--- a/Runtime/Native/Android/NativeClient.cs
+++ b/Runtime/Native/Android/NativeClient.cs
@@ -158,14 +158,19 @@ namespace Backtrace.Unity.Runtime.Native.Android
         /// <returns>Guessed path to lib directory</returns>
         private string GuessNativeDirectoryPath(string processAbi)
         {
-            var sourceDirectory = Path.Combine(Path.GetDirectoryName(Application.dataPath), "lib");
-            if (!Directory.Exists(sourceDirectory))
+            try
             {
+                return AndroidNativeLibraryPathResolver.TryGuessNativeLibraryDirectory(
+                    Application.dataPath,
+                    processAbi,
+                    Directory.Exists,
+                    Directory.GetDirectories) ?? string.Empty;
+            }
+            catch (Exception)
+            {
+                // This legacy directory hint is optional. It must never prevent the authoritative linker path or installed-package metadata from resolving.
                 return string.Empty;
             }
-            var libDirectories = Directory.GetDirectories(sourceDirectory);
-            return AndroidNativeLibraryPathResolver.SelectNativeLibraryDirectory(libDirectories, processAbi)
-                ?? string.Empty;
         }
 
         /// <summary>
@@ -258,14 +263,6 @@ namespace Backtrace.Unity.Runtime.Native.Android
             return exception == null ? "unknown" : exception.GetType().FullName;
         }
 
-        private static void DeleteLocalReference(IntPtr reference)
-        {
-            if (reference != IntPtr.Zero)
-            {
-                AndroidJNI.DeleteLocalRef(reference);
-            }
-        }
-
         /// <summary>
         /// Sets one native crash attribute with deterministic JNI local-reference cleanup.
         /// native attribute write goes through this helper:
@@ -283,8 +280,10 @@ namespace Backtrace.Unity.Runtime.Native.Android
             }
             finally
             {
-                DeleteLocalReference(valueReference);
-                DeleteLocalReference(keyReference);
+                AndroidNativeInitialization.DeleteLocalReferences(
+                    AndroidJNI.DeleteLocalRef,
+                    valueReference,
+                    keyReference);
             }
         }
 
@@ -302,7 +301,9 @@ namespace Backtrace.Unity.Runtime.Native.Android
             }
             finally
             {
-                DeleteLocalReference(messageReference);
+                AndroidNativeInitialization.DeleteLocalReferences(
+                    AndroidJNI.DeleteLocalRef,
+                    messageReference);
             }
         }
 
@@ -313,7 +314,8 @@ namespace Backtrace.Unity.Runtime.Native.Android
             string[] attributeKeys,
             string[] attributeValues,
             string[] attachments,
-            string[] environmentVariables)
+            string[] environmentVariables,
+            Action markNativeBackendActive)
         {
             IntPtr urlRef = IntPtr.Zero;
             IntPtr databaseRef = IntPtr.Zero;
@@ -331,7 +333,7 @@ namespace Backtrace.Unity.Runtime.Native.Android
                 valuesRef = AndroidJNIHelper.ConvertToJNIArray(attributeValues ?? new string[0]);
                 attachmentsRef = AndroidJNIHelper.ConvertToJNIArray(attachments ?? new string[0]);
                 environmentRef = AndroidJNIHelper.ConvertToJNIArray(environmentVariables ?? new string[0]);
-                return AndroidNativeInterop.InitializeJavaCrashHandler(
+                bool initialized = AndroidNativeInterop.InitializeJavaCrashHandler(
                     urlRef,
                     databaseRef,
                     classRef,
@@ -339,16 +341,25 @@ namespace Backtrace.Unity.Runtime.Native.Android
                     valuesRef,
                     attachmentsRef,
                     environmentRef);
+                if (initialized)
+                {
+                    // Record activation before local-reference cleanup.
+                    // If that cleanup throws, the caller must still disable the already-active backend.
+                    markNativeBackendActive();
+                }
+                return initialized;
             }
             finally
             {
-                DeleteLocalReference(environmentRef);
-                DeleteLocalReference(attachmentsRef);
-                DeleteLocalReference(valuesRef);
-                DeleteLocalReference(keysRef);
-                DeleteLocalReference(classRef);
-                DeleteLocalReference(databaseRef);
-                DeleteLocalReference(urlRef);
+                AndroidNativeInitialization.DeleteLocalReferences(
+                    AndroidJNI.DeleteLocalRef,
+                    environmentRef,
+                    attachmentsRef,
+                    valuesRef,
+                    keysRef,
+                    classRef,
+                    databaseRef,
+                    urlRef);
             }
         }
 
@@ -466,33 +477,36 @@ namespace Backtrace.Unity.Runtime.Native.Android
                 handlerPath,
                 BuildLibrarySearchPaths(applicationInfo.NativeLibraryDir));
 
-            var initialized = InvokeInitialize(
-                minidumpUrl,
-                databasePath,
-                _crashHandlerPath,
-                new string[0],
-                new string[0],
-                attachments == null ? new string[0] : attachments.ToArray(),
-                environmentVariables);
+            var initialized = AndroidNativeInitialization.Execute(
+                markNativeBackendActive => InvokeInitialize(
+                    minidumpUrl,
+                    databasePath,
+                    _crashHandlerPath,
+                    new string[0],
+                    new string[0],
+                    attachments == null ? new string[0] : attachments.ToArray(),
+                    environmentVariables,
+                    markNativeBackendActive),
+                () =>
+                {
+                    foreach (var attribute in backtraceAttributes)
+                    {
+                        SetNativeAttribute(attribute.Key, attribute.Value);
+                    }
+
+                    // Add exception type to crashes handled by crashpad.
+                    // ANR and OOM reporting override this value temporarily at runtime.
+                    SetNativeAttribute(ErrorTypeAttribute, CrashType);
+                },
+                AndroidNativeInterop.Disable,
+                rollbackFailure => Debug.LogWarning(
+                    "BT_UNITY_ANDROID_NATIVE_ROLLBACK_FAILURE: Native initialization rollback failed. "
+                        + "Failure type: " + FailureType(rollbackFailure)));
             if (!initialized)
             {
                 Debug.LogWarning("Backtrace native integration status: Cannot initialize Java crash handler");
                 return false;
             }
-
-            foreach (var attribute in backtraceAttributes)
-            {
-                SetNativeAttribute(attribute.Key, attribute.Value);
-            }
-
-            // add exception type to crashes handled by crashpad - all exception handled by crashpad
-            // by default we setting this option here, to set error.type when unexpected crash happen (so attribute will present)
-            // otherwise in other methods - ANR detection, OOM handler, we're overriding it and setting it back to "crash"
-
-            // warning
-            // don't add attributes that can change over the time to initialization method attributes. Crashpad will prevent from overriding them on game runtime.
-            // ANRs/OOMs methods can override error.type attribute, so we shouldn't pass error.type attribute via attributes parameters.
-            SetNativeAttribute(ErrorTypeAttribute, CrashType);
             return true;
         }
 
@@ -510,19 +524,14 @@ namespace Backtrace.Unity.Runtime.Native.Android
 
         private List<string> BuildLibrarySearchPaths(string nativeLibraryDir)
         {
-            var searchPaths = new List<string>();
-            if (!string.IsNullOrEmpty(nativeLibraryDir))
-            {
-                searchPaths.Add(nativeLibraryDir);
-                var parent = Directory.GetParent(nativeLibraryDir);
-                if (parent != null)
+            return AndroidCrashHandlerEnvironment.BuildLibrarySearchPaths(
+                nativeLibraryDir,
+                path =>
                 {
-                    searchPaths.Add(parent.ToString());
-                }
-            }
-            searchPaths.Add(GetLibrarySystemPath());
-            searchPaths.Add("/data/local");
-            return searchPaths;
+                    var parent = Directory.GetParent(path);
+                    return parent == null ? null : parent.ToString();
+                },
+                GetLibrarySystemPath).ToList();
         }
 
         private string GetLibrarySystemPath() {
@@ -609,91 +618,59 @@ namespace Backtrace.Unity.Runtime.Native.Android
             bool reported = false;
             AnrThread = new Thread(() =>
             {
-                // Attach the Unity-created watchdog thread to the JVM exactly once and detach it when the loop ends;
-                // attaching per report leaked the attachment for the thread's lifetime.
-                // The Unity main thread is never detached here, this is the watchdog thread only.
-                bool attached = AndroidJNI.AttachCurrentThread() == 0;
-                try
-                {
-                    float lastUpdatedCache = 0;
-                    while (AnrThread.IsAlive && StopAnr == false)
+                AndroidAnrThreadLifecycle.Run(
+                    AndroidJNI.AttachCurrentThread,
+                    tryAttach =>
                     {
-                        if (!PreventAnr)
+                        // Attach the Unity-created watchdog thread to the JVM exactly once and detach it when the loop ends;
+                        // attaching per report leaked the attachment for the thread's lifetime.
+                        // The Unity main thread is never detached here, this is the watchdog thread only.
+                        float lastUpdatedCache = 0;
+                        while (AnrThread.IsAlive && StopAnr == false)
                         {
-                            if (lastUpdatedCache == 0)
+                            if (!PreventAnr)
                             {
-                                lastUpdatedCache = LastUpdateTime;
-                            }
-                            else if (lastUpdatedCache == LastUpdateTime)
-                            {
-                                if (!reported)
+                                if (lastUpdatedCache == 0)
                                 {
-                                    OnAnrDetection();
-                                    if (!attached)
+                                    lastUpdatedCache = LastUpdateTime;
+                                }
+                                else if (lastUpdatedCache == LastUpdateTime)
+                                {
+                                    if (!reported)
                                     {
+                                        OnAnrDetection();
                                         // A transient early attach failure (JVM resource pressure) must not permanently disable hang dumps;
                                         // reported stays false so the next iteration retries this hang.
-                                        attached = AndroidJNI.AttachCurrentThread() == 0;
-                                    }
-                                    if (attached)
-                                    {
-                                        reported = true;
-                                        // The temporary Hang classification must be restored to Crash even when the dump fails,
-                                        // or a later native crash would be misclassified as a hang.
-                                        bool hangTypeApplied = false;
-                                        try
+                                        if (tryAttach())
                                         {
-                                            SetNativeAttribute(ErrorTypeAttribute, HangType);
-                                            hangTypeApplied = true;
-                                            SendNativeDump(AnrMessage, true);
-                                        }
-                                        catch (Exception exception)
-                                        {
-                                            Debug.LogWarning(
-                                                "BT_UNITY_ANDROID_NATIVE_DUMP_FAILURE: Failure type: "
-                                                    + FailureType(exception));
-                                        }
-                                        finally
-                                        {
-                                            if (hangTypeApplied)
-                                            {
-                                                try
-                                                {
-                                                    SetNativeAttribute(ErrorTypeAttribute, CrashType);
-                                                }
-                                                catch (Exception exception)
-                                                {
-                                                    Debug.LogWarning(
-                                                        "BT_UNITY_ANDROID_NATIVE_ATTRIBUTE_FAILURE: Failure type: "
-                                                            + FailureType(exception));
-                                                }
-                                            }
+                                            reported = true;
+                                            // The temporary Hang classification must be restored to Crash even when the dump fails,
+                                            // or a later native crash would be misclassified as a hang.
+                                            AndroidAnrThreadLifecycle.CaptureNativeDump(
+                                                () => SetNativeAttribute(ErrorTypeAttribute, HangType),
+                                                () => SendNativeDump(AnrMessage, true),
+                                                () => SetNativeAttribute(ErrorTypeAttribute, CrashType),
+                                                warning => Debug.LogWarning(warning));
                                         }
                                     }
                                 }
-                            }
-                            else
-                            {
-                                reported = false;
-                            }
+                                else
+                                {
+                                    reported = false;
+                                }
 
-                            lastUpdatedCache = LastUpdateTime;
+                                lastUpdatedCache = LastUpdateTime;
+                            }
+                            else if (lastUpdatedCache != 0)
+                            {
+                                // make sure when ANR happened just after going to foreground we won't false positive ANR report
+                                lastUpdatedCache = 0;
+                            }
+                            Thread.Sleep(AnrWatchdogTimeout);
                         }
-                        else if (lastUpdatedCache != 0)
-                        {
-                            // make sure when ANR happened just after going to foreground we won't false positive ANR report
-                            lastUpdatedCache = 0;
-                        }
-                        Thread.Sleep(AnrWatchdogTimeout);
-                    }
-                }
-                finally
-                {
-                    if (attached)
-                    {
-                        AndroidJNI.DetachCurrentThread();
-                    }
-                }
+                    },
+                    () => { AndroidJNI.DetachCurrentThread(); },
+                    warning => Debug.LogWarning(warning));
             });
             AnrThread.IsBackground = true;
             AnrThread.Start();
@@ -730,36 +707,26 @@ namespace Backtrace.Unity.Runtime.Native.Android
         /// </summary>
         public override void Disable()
         {
-            // Disabling is contained like setup: a native failure must not leave the component half-disabled or crash the caller, and it logs the failure class only.
-            try
-            {
-                if (CaptureNativeCrashes)
-                {
-                    AndroidNativeInterop.Disable();
-                }
-            }
-            catch (Exception exception)
-            {
-                Debug.LogWarning(
-                    "BT_UNITY_ANDROID_NATIVE_DISABLE_FAILURE: Failure type: " + FailureType(exception));
-            }
-            finally
-            {
-                CaptureNativeCrashes = false;
-            }
-            if (_anrWatcher != null)
-            {
-                _anrWatcher.Call("stopMonitoring");
-                _anrWatcher.Dispose();
-                _anrWatcher = null;
-            }
-            if (_unhandledExceptionWatcher != null)
-            {
-                _unhandledExceptionWatcher.Call("stopMonitoring");
-                _unhandledExceptionWatcher.Dispose();
-                _unhandledExceptionWatcher = null;
-            }
-            base.Disable();
+            bool disableNativeIntegration = CaptureNativeCrashes;
+            CaptureNativeCrashes = false;
+
+            // Clear the shared references before any JNI cleanup.
+            // Even when a stop or dispose call fails, later Disable calls cannot reuse a partially disposed watcher.
+            var anrWatcher = _anrWatcher;
+            _anrWatcher = null;
+            var unhandledExceptionWatcher = _unhandledExceptionWatcher;
+            _unhandledExceptionWatcher = null;
+
+            AndroidNativeDisableLifecycle.Run(
+                () => base.Disable(),
+                disableNativeIntegration ? new Action(AndroidNativeInterop.Disable) : null,
+                anrWatcher == null ? null : new Action(() => anrWatcher.Call("stopMonitoring")),
+                anrWatcher == null ? null : new Action(anrWatcher.Dispose),
+                unhandledExceptionWatcher == null
+                    ? null
+                    : new Action(() => unhandledExceptionWatcher.Call("stopMonitoring")),
+                unhandledExceptionWatcher == null ? null : new Action(unhandledExceptionWatcher.Dispose),
+                warning => Debug.LogWarning(warning));
         }
     }
 }

--- a/Tests/Runtime/Native/Android/AndroidAnrThreadLifecycleTests.cs
+++ b/Tests/Runtime/Native/Android/AndroidAnrThreadLifecycleTests.cs
@@ -1,0 +1,133 @@
+#if UNITY_ANDROID || UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using Backtrace.Unity.Runtime.Native.Android;
+using NUnit.Framework;
+
+namespace Backtrace.Unity.Tests.Runtime
+{
+    public class AndroidAnrThreadLifecycleTests
+    {
+        [Test]
+        public void AttachExceptionIsContainedAndSanitized()
+        {
+            var warnings = new List<string>();
+            bool watchdogRan = false;
+            int detachCalls = 0;
+
+            Assert.DoesNotThrow(() => AndroidAnrThreadLifecycle.Run(
+                () => { throw new InvalidOperationException("sensitive attach detail"); },
+                tryAttach => { watchdogRan = true; },
+                () => { detachCalls++; },
+                warnings.Add));
+
+            Assert.IsFalse(watchdogRan);
+            Assert.AreEqual(0, detachCalls);
+            CollectionAssert.AreEqual(
+                new[] { "BT_UNITY_ANDROID_ANR_THREAD_FAILURE: Failure type: System.InvalidOperationException" },
+                warnings);
+            StringAssert.DoesNotContain("sensitive attach detail", warnings[0]);
+        }
+
+        [Test]
+        public void NonzeroAttachResultIsRetriedAndEventuallyDetached()
+        {
+            int attachCalls = 0;
+            int detachCalls = 0;
+            bool retrySucceeded = false;
+            var warnings = new List<string>();
+
+            AndroidAnrThreadLifecycle.Run(
+                () => ++attachCalls == 1 ? -1 : 0,
+                tryAttach => { retrySucceeded = tryAttach(); },
+                () => { detachCalls++; },
+                warnings.Add);
+
+            Assert.AreEqual(2, attachCalls);
+            Assert.IsTrue(retrySucceeded);
+            Assert.AreEqual(1, detachCalls);
+            Assert.IsEmpty(warnings);
+        }
+
+        [Test]
+        public void DetachExceptionIsContainedAndSanitized()
+        {
+            var warnings = new List<string>();
+
+            Assert.DoesNotThrow(() => AndroidAnrThreadLifecycle.Run(
+                () => 0,
+                tryAttach => { },
+                () => { throw new InvalidOperationException("sensitive detach detail"); },
+                warnings.Add));
+
+            CollectionAssert.AreEqual(
+                new[] { "BT_UNITY_ANDROID_JNI_DETACH_FAILURE: Failure type: System.InvalidOperationException" },
+                warnings);
+            StringAssert.DoesNotContain("sensitive detach detail", warnings[0]);
+        }
+
+        [Test]
+        public void HangTypeWriteFailureIsClassifiedAndStillRestoresCrashType()
+        {
+            var warnings = new List<string>();
+            string errorType = "Crash";
+            bool dumpSent = false;
+
+            AndroidAnrThreadLifecycle.CaptureNativeDump(
+                () =>
+                {
+                    // Mirrors SetNativeAttribute: the native write completed, then JNI
+                    // local-reference cleanup failed before the method returned.
+                    errorType = "Hang";
+                    throw new InvalidOperationException("sensitive cleanup detail");
+                },
+                () => { dumpSent = true; },
+                () => { errorType = "Crash"; },
+                warnings.Add);
+
+            Assert.AreEqual("Crash", errorType);
+            Assert.IsFalse(dumpSent);
+            CollectionAssert.AreEqual(
+                new[] { "BT_UNITY_ANDROID_NATIVE_ATTRIBUTE_FAILURE: Failure type: System.InvalidOperationException" },
+                warnings);
+            StringAssert.DoesNotContain("sensitive cleanup detail", warnings[0]);
+        }
+
+        [Test]
+        public void NativeDumpFailureStillRestoresCrashType()
+        {
+            var warnings = new List<string>();
+            string errorType = "Crash";
+
+            AndroidAnrThreadLifecycle.CaptureNativeDump(
+                () => { errorType = "Hang"; },
+                () => { throw new InvalidOperationException("sensitive dump detail"); },
+                () => { errorType = "Crash"; },
+                warnings.Add);
+
+            Assert.AreEqual("Crash", errorType);
+            CollectionAssert.AreEqual(
+                new[] { "BT_UNITY_ANDROID_NATIVE_DUMP_FAILURE: Failure type: System.InvalidOperationException" },
+                warnings);
+            StringAssert.DoesNotContain("sensitive dump detail", warnings[0]);
+        }
+
+        [Test]
+        public void CrashTypeRestorationFailureIsContainedAndSanitized()
+        {
+            var warnings = new List<string>();
+
+            Assert.DoesNotThrow(() => AndroidAnrThreadLifecycle.CaptureNativeDump(
+                () => { },
+                () => { },
+                () => { throw new InvalidOperationException("sensitive restore detail"); },
+                warnings.Add));
+
+            CollectionAssert.AreEqual(
+                new[] { "BT_UNITY_ANDROID_NATIVE_ATTRIBUTE_FAILURE: Failure type: System.InvalidOperationException" },
+                warnings);
+            StringAssert.DoesNotContain("sensitive restore detail", warnings[0]);
+        }
+    }
+}
+#endif

--- a/Tests/Runtime/Native/Android/AndroidAnrThreadLifecycleTests.cs.meta
+++ b/Tests/Runtime/Native/Android/AndroidAnrThreadLifecycleTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76c56ea8daeb41e9ab1fdb53d667437a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/Native/Android/AndroidCrashHandlerEnvironmentTests.cs
+++ b/Tests/Runtime/Native/Android/AndroidCrashHandlerEnvironmentTests.cs
@@ -115,6 +115,19 @@ namespace Backtrace.Unity.Tests.Runtime
             Assert.DoesNotThrow(
                 () => AndroidCrashHandlerEnvironment.BuildEnvironment(null, ClassPath, HandlerPath, null));
         }
+
+        [Test]
+        public void OptionalSearchPathFailuresKeepUsableFallbacks()
+        {
+            var searchPaths = AndroidCrashHandlerEnvironment.BuildLibrarySearchPaths(
+                "/data/app/example/lib/arm64",
+                path => { throw new InvalidOperationException("parent lookup failed"); },
+                () => { throw new InvalidOperationException("java.library.path lookup failed"); });
+
+            CollectionAssert.AreEqual(
+                new[] { "/data/app/example/lib/arm64", "/data/local" },
+                searchPaths);
+        }
     }
 }
 #endif

--- a/Tests/Runtime/Native/Android/AndroidNativeDisableLifecycleTests.cs
+++ b/Tests/Runtime/Native/Android/AndroidNativeDisableLifecycleTests.cs
@@ -1,0 +1,114 @@
+#if UNITY_ANDROID || UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using Backtrace.Unity.Runtime.Native.Android;
+using NUnit.Framework;
+
+namespace Backtrace.Unity.Tests.Runtime
+{
+    public class AndroidNativeDisableLifecycleTests
+    {
+        [Test]
+        public void EveryCleanupStageRunsInOrderWhenEarlierStagesFail()
+        {
+            var stages = new List<string>();
+            var warnings = new List<string>();
+
+            Assert.DoesNotThrow(() => AndroidNativeDisableLifecycle.Run(
+                () =>
+                {
+                    stages.Add("anr-thread");
+                    throw new InvalidOperationException("sensitive anr thread detail");
+                },
+                () =>
+                {
+                    stages.Add("native");
+                    throw new InvalidOperationException("sensitive native detail");
+                },
+                () =>
+                {
+                    stages.Add("anr-stop");
+                    throw new InvalidOperationException("sensitive anr stop detail");
+                },
+                () =>
+                {
+                    stages.Add("anr-dispose");
+                    throw new InvalidOperationException("sensitive anr dispose detail");
+                },
+                () =>
+                {
+                    stages.Add("unhandled-stop");
+                    throw new InvalidOperationException("sensitive unhandled stop detail");
+                },
+                () =>
+                {
+                    stages.Add("unhandled-dispose");
+                    throw new InvalidOperationException("sensitive unhandled dispose detail");
+                },
+                warnings.Add));
+
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    "anr-thread",
+                    "native",
+                    "anr-stop",
+                    "anr-dispose",
+                    "unhandled-stop",
+                    "unhandled-dispose"
+                },
+                stages);
+            CollectionAssert.AreEqual(
+                new[]
+                {
+                    "BT_UNITY_ANDROID_ANR_STOP_FAILURE: Failure type: System.InvalidOperationException",
+                    "BT_UNITY_ANDROID_NATIVE_DISABLE_FAILURE: Failure type: System.InvalidOperationException",
+                    "BT_UNITY_ANDROID_ANR_WATCHER_STOP_FAILURE: Failure type: System.InvalidOperationException",
+                    "BT_UNITY_ANDROID_ANR_WATCHER_DISPOSE_FAILURE: Failure type: System.InvalidOperationException",
+                    "BT_UNITY_ANDROID_UNHANDLED_WATCHER_STOP_FAILURE: Failure type: System.InvalidOperationException",
+                    "BT_UNITY_ANDROID_UNHANDLED_WATCHER_DISPOSE_FAILURE: Failure type: System.InvalidOperationException"
+                },
+                warnings);
+
+            foreach (var warning in warnings)
+            {
+                StringAssert.DoesNotContain("sensitive", warning);
+            }
+        }
+
+        [Test]
+        public void MissingOptionalCleanupStagesDoNotSkipAnrThreadStop()
+        {
+            int stopAnrCalls = 0;
+
+            Assert.DoesNotThrow(() => AndroidNativeDisableLifecycle.Run(
+                () => { stopAnrCalls++; },
+                null,
+                null,
+                null,
+                null,
+                null,
+                null));
+
+            Assert.AreEqual(1, stopAnrCalls);
+        }
+
+        [Test]
+        public void LoggingFailureCannotInterruptRemainingCleanup()
+        {
+            int cleanupCalls = 0;
+
+            Assert.DoesNotThrow(() => AndroidNativeDisableLifecycle.Run(
+                () => { throw new InvalidOperationException(); },
+                () => { cleanupCalls++; },
+                () => { cleanupCalls++; },
+                () => { cleanupCalls++; },
+                () => { cleanupCalls++; },
+                () => { cleanupCalls++; },
+                warning => { throw new InvalidOperationException(); }));
+
+            Assert.AreEqual(5, cleanupCalls);
+        }
+    }
+}
+#endif

--- a/Tests/Runtime/Native/Android/AndroidNativeDisableLifecycleTests.cs.meta
+++ b/Tests/Runtime/Native/Android/AndroidNativeDisableLifecycleTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1376072d00c942399cbd12c93dd0d9e6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/Native/Android/AndroidNativeInitializationTests.cs
+++ b/Tests/Runtime/Native/Android/AndroidNativeInitializationTests.cs
@@ -1,0 +1,116 @@
+#if UNITY_ANDROID || UNITY_EDITOR
+using System;
+using System.Collections.Generic;
+using Backtrace.Unity.Runtime.Native.Android;
+using NUnit.Framework;
+
+namespace Backtrace.Unity.Tests.Runtime
+{
+    public class AndroidNativeInitializationTests
+    {
+        [Test]
+        public void RejectedInitializationDoesNotCompleteOrRollback()
+        {
+            int completionCount = 0;
+            int rollbackCount = 0;
+
+            bool initialized = AndroidNativeInitialization.Execute(
+                markActive => false,
+                () => completionCount++,
+                () => rollbackCount++,
+                null);
+
+            Assert.IsFalse(initialized);
+            Assert.AreEqual(0, completionCount);
+            Assert.AreEqual(0, rollbackCount);
+        }
+
+        [Test]
+        public void AttributeSetupFailureRollsBackActiveBackend()
+        {
+            var setupFailure = new InvalidOperationException("attribute setup failed");
+            int rollbackCount = 0;
+
+            var thrown = Assert.Throws<InvalidOperationException>(() => AndroidNativeInitialization.Execute(
+                markActive =>
+                {
+                    markActive();
+                    return true;
+                },
+                () => { throw setupFailure; },
+                () => rollbackCount++,
+                null));
+
+            Assert.AreSame(setupFailure, thrown);
+            Assert.AreEqual(1, rollbackCount);
+        }
+
+        [Test]
+        public void CleanupFailureAfterActivationRollsBackBackend()
+        {
+            var cleanupFailure = new InvalidOperationException("JNI cleanup failed");
+            int completionCount = 0;
+            int rollbackCount = 0;
+
+            var thrown = Assert.Throws<InvalidOperationException>(() => AndroidNativeInitialization.Execute(
+                markActive =>
+                {
+                    // Mirrors InvokeInitialize: native code returned true, then its finally
+                    // block failed while deleting a local reference.
+                    markActive();
+                    throw cleanupFailure;
+                },
+                () => completionCount++,
+                () => rollbackCount++,
+                null));
+
+            Assert.AreSame(cleanupFailure, thrown);
+            Assert.AreEqual(0, completionCount);
+            Assert.AreEqual(1, rollbackCount);
+        }
+
+        [Test]
+        public void RollbackFailureDoesNotReplaceSetupFailure()
+        {
+            var setupFailure = new InvalidOperationException("attribute setup failed");
+            var rollbackFailure = new ApplicationException("rollback failed");
+            Exception reportedFailure = null;
+
+            var thrown = Assert.Throws<InvalidOperationException>(() => AndroidNativeInitialization.Execute(
+                markActive => true,
+                () => { throw setupFailure; },
+                () => { throw rollbackFailure; },
+                exception => reportedFailure = exception));
+
+            Assert.AreSame(setupFailure, thrown);
+            Assert.AreSame(rollbackFailure, reportedFailure);
+        }
+
+        [Test]
+        public void LocalReferenceFailureDoesNotSkipRemainingReferences()
+        {
+            var firstReference = new IntPtr(1);
+            var secondReference = new IntPtr(2);
+            var cleanupFailure = new InvalidOperationException("first cleanup failed");
+            var attempted = new List<IntPtr>();
+
+            var thrown = Assert.Throws<InvalidOperationException>(() =>
+                AndroidNativeInitialization.DeleteLocalReferences(
+                    reference =>
+                    {
+                        attempted.Add(reference);
+                        if (reference == firstReference)
+                        {
+                            throw cleanupFailure;
+                        }
+                    },
+                    IntPtr.Zero,
+                    firstReference,
+                    secondReference));
+
+            Assert.AreSame(cleanupFailure, thrown);
+            CollectionAssert.AreEqual(new[] { firstReference, secondReference }, attempted);
+        }
+    }
+}
+#endif

--- a/Tests/Runtime/Native/Android/AndroidNativeInitializationTests.cs.meta
+++ b/Tests/Runtime/Native/Android/AndroidNativeInitializationTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d2753a4e78fe4c50a66717df21709d2f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Tests/Runtime/Native/Android/AndroidNativeLibraryPathResolverTests.cs
+++ b/Tests/Runtime/Native/Android/AndroidNativeLibraryPathResolverTests.cs
@@ -29,6 +29,39 @@ namespace Backtrace.Unity.Tests.Runtime
         }
 
         [Test]
+        public void LegacyNativeDirectoryGuessUsesProcessAbi()
+        {
+            var armDirectory = "/data/app/example/lib/arm";
+            var arm64Directory = "/data/app/example/lib/arm64";
+
+            var resolved = AndroidNativeLibraryPathResolver.TryGuessNativeLibraryDirectory(
+                BaseApk,
+                "arm64-v8a",
+                path => path == "/data/app/example/lib",
+                path => new[] { armDirectory, arm64Directory });
+
+            Assert.AreEqual(arm64Directory, resolved);
+        }
+
+        [Test]
+        public void LegacyNativeDirectoryGuessContainsFilesystemFailures()
+        {
+            string existsFailure = AndroidNativeLibraryPathResolver.TryGuessNativeLibraryDirectory(
+                BaseApk,
+                "arm64-v8a",
+                path => { throw new InvalidOperationException("exists failed"); },
+                path => new string[0]);
+            string enumerationFailure = AndroidNativeLibraryPathResolver.TryGuessNativeLibraryDirectory(
+                BaseApk,
+                "arm64-v8a",
+                path => true,
+                path => { throw new InvalidOperationException("enumeration failed"); });
+
+            Assert.IsNull(existsFailure);
+            Assert.IsNull(enumerationFailure);
+        }
+
+        [Test]
         public void AbsoluteLoadedLibraryPathIsAuthoritative()
         {
             var loaded = "/data/app/example/lib/arm64/" + Library;
@@ -278,6 +311,33 @@ namespace Backtrace.Unity.Tests.Runtime
             Assert.AreEqual("/data/app/example/lib/arm64", selected);
         }
 
+        [TestCase(false)]
+        [TestCase(true)]
+        public void DirectoryGuessRejectsMultipleExactArm64AliasesRegardlessOfOrder(bool reverseOrder)
+        {
+            var arm64 = "/data/app/example/lib/arm64";
+            var arm64V8a = "/data/app/example/lib/arm64-v8a";
+            string[] candidates = reverseOrder
+                ? new[] { arm64V8a, arm64 }
+                : new[] { arm64, arm64V8a };
+
+            var selected = AndroidNativeLibraryPathResolver.SelectNativeLibraryDirectory(
+                candidates, "arm64-v8a");
+
+            Assert.IsNull(selected);
+        }
+
+        [Test]
+        public void DirectoryGuessDeduplicatesRepeatedExactCandidate()
+        {
+            var arm64 = "/data/app/example/lib/arm64";
+
+            var selected = AndroidNativeLibraryPathResolver.SelectNativeLibraryDirectory(
+                new[] { arm64, arm64 }, "arm64-v8a");
+
+            Assert.AreEqual(arm64, selected);
+        }
+
         [Test]
         public void DirectoryGuessSelectsArmDirectoryForArmV7Process()
         {
@@ -307,18 +367,30 @@ namespace Backtrace.Unity.Tests.Runtime
         }
 
         [Test]
-        public void DirectoryGuessSingleCandidateRemainsACompatibilityFallback()
+        public void DirectoryGuessKnownAbiRejectsSingleMismatchedCandidate()
         {
             var selected = AndroidNativeLibraryPathResolver.SelectNativeLibraryDirectory(
                 new[] { "/data/app/example/lib/somedir" }, "arm64-v8a");
 
-            Assert.AreEqual("/data/app/example/lib/somedir", selected);
+            Assert.IsNull(selected);
+        }
 
-            // Even with an undetermined ABI, one unique directory is still usable.
-            Assert.AreEqual(
-                "/data/app/example/lib/somedir",
-                AndroidNativeLibraryPathResolver.SelectNativeLibraryDirectory(
-                    new[] { "/data/app/example/lib/somedir" }, null));
+        [Test]
+        public void DirectoryGuessUnknownAbiUsesSingleCandidateAsCompatibilityFallback()
+        {
+            var selected = AndroidNativeLibraryPathResolver.SelectNativeLibraryDirectory(
+                new[] { "/data/app/example/lib/somedir" }, null);
+
+            Assert.AreEqual("/data/app/example/lib/somedir", selected);
+        }
+
+        [Test]
+        public void DirectoryGuessUnknownAbiRejectsAmbiguousCandidates()
+        {
+            var selected = AndroidNativeLibraryPathResolver.SelectNativeLibraryDirectory(
+                new[] { "/data/app/example/lib/arm", "/data/app/example/lib/arm64" }, null);
+
+            Assert.IsNull(selected);
         }
 
         [Test]


### PR DESCRIPTION
## Summary

This PR improves the reliability of native crash reporting on Android, particularly during SDK startup, App Bundle and split-APK installations, ANR reporting, and native shutdown.

Native-library resolution now prioritizes the path selected by Android’s linker and uses process-aware extracted library and installed split metadata as fallbacks. Optional filesystem, application metadata, and Java environment lookups cannot prevent an otherwise valid native initialization.

The changes also make native initialization transactional, contain optional JNI and lifecycle failures, and ensure managed Unity reporting remains available when native crash capture cannot be enabled.

## What changed

### Native-library resolution

- Use the native-library path selected by Android’s linker as the authoritative result.
- Support extracted native libraries, Android App Bundles, and ABI split APKs.
- Use the ABI of the running process rather than the device-preferred ABI.
- Require exact ABI matches when the process ABI is known.
- Reject ambiguous or mismatched native-library directory candidates.
- Keep optional directory and environment discovery from blocking linker or package-metadata resolution.
- Resolve native libraries without inspecting APK archive contents.

### Native initialization

- Track when the native backend becomes active.
- Roll back the backend when JNI cleanup or initial attribute configuration fails after activation.
- Attempt cleanup for every allocated JNI local reference even when an earlier cleanup operation fails.
- Preserve the original initialization failure when rollback also fails.
- Keep native setup failures contained so managed reporting can continue.

### ANR and native dump lifecycle

- Contain JVM attach and detach failures in the ANR worker.
- Retry transient JVM attachment failures.
- Distinguish native dump failures from native attribute failures.
- Always attempt to restore `error.type` from `Hang` to `Crash`.
- Prevent optional logging failures from escaping the ANR worker.

### Native shutdown

- Clear native state and Java watcher references before cleanup begins.
- Stop the ANR worker independently from native and Java watcher cleanup.
- Execute native disable and each watcher stop/dispose operation independently.
- Prevent one cleanup failure from skipping later shutdown stages.
- Emit stable diagnostics containing the failure type without exception messages or application data.

### Native bridge and crash-handler behavior

- Correct native P/Invoke return types.
- Release JNI local references deterministically.
- Keep crash-handler load and dispatch failures nonfatal to the host application.
- Avoid logging submission arguments, attributes, attachments, or resolved native-library paths.
- Update the bundled Backtrace Android native libraries.

### CI coverage

- Compile the SDK under `UNITY_ANDROID` in every Android build lane.
- Cover Android builds on Unity 2019.4, Unity 2022.3, and Unity 6.
- Add a Unity 6 ARM64 IL2CPP App Bundle build.
- Verify that the generated App Bundle contains:
  - `lib/arm64-v8a/libil2cpp.so`
  - `lib/arm64-v8a/libbacktrace-native.so`
- Include the target platform and Unity version in build job names.
- Keep unrelated iOS, macOS, Windows, test, and package metadata outside the Android project’s `Assets` directory.

## Compatibility

- No public Unity API is removed or renamed.
- Managed Unity reporting remains available when native initialization fails.
- Native Crashpad reporting requires Android API 21 or later.
- Native crash capture supports:
  - `arm64-v8a`
  - `armeabi-v7a`
  - `x86_64`
- Native `x86` capture remains unsupported; managed reporting continues.
- Both monolithic APK and Android App Bundle/split-APK installations are supported.

ref: BT-7495
ref: BT-7496
ref: BT-7497
ref: BT-7498
ref: BT-7499
ref: BT-7500